### PR TITLE
Pydantic v2 compatability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
             --file requirements.txt
             --file requirements-dev.txt
             --channel conda-forge
-            pydantic=${{ matrix.pydantic-version }}
+            pydantic${{ matrix.pydantic-version }}
 
       - name: Install xpublish-edr
         shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
         os: [windows-latest, ubuntu-latest, macos-latest]
+        pydantic-version: ["<2", ">=2"]
 
     steps:
       - uses: actions/checkout@v2
@@ -21,10 +22,10 @@ jobs:
         with:
           environment-file: false
 
-      - name: Python ${{ matrix.python-version }}
+      - name: Python ${{ matrix.python-version }} Pydantic ${{ matrix.pydantic-version }}
         shell: bash -l {0}
         run: >
-          micromamba create --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt --channel conda-forge
+          micromamba create --name TEST python=${{ matrix.python-version }} --file requirements.txt --file requirements-dev.txt --channel conda-forge pydantic=${{ matrix.pydantic-version }}
           && micromamba activate TEST
           && pip install -e . --no-deps --force-reinstall
           && micromamba info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,8 @@ repos:
       - id: mypy
         exclude: docs/source/conf.py
         args: [--ignore-missing-imports]
-        additional_dependencies: [typing_extensions>=4.2.0, types-setuptools]
+        additional_dependencies:
+          [typing_extensions>=4.2.0, types-setuptools, types-PyYAML]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,3 +16,4 @@ exclude *.enc
 exclude .gitignore
 exclude .isort.cfg
 exclude .pre-commit-config.yaml
+exclude noxfile.py

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,19 @@
+"""Test against the same matrix as Github Actions"""
+import nox
+import yaml
+
+with open("./.github/workflows/tests.yml") as f:
+    workflow = yaml.safe_load(f)
+
+python_versions = workflow["jobs"]["run"]["strategy"]["matrix"]["python-version"]
+pydantic_versions = workflow["jobs"]["run"]["strategy"]["matrix"]["pydantic-version"]
+
+
+@nox.session(python=python_versions)
+@nox.parametrize("pydantic", pydantic_versions)
+def tests(session: nox.Session, pydantic: str):
+    """Run py.test against Github Actions matrix"""
+    session.install("-r", "requirements-dev.txt")
+    session.install(".")
+    session.install(f"pydantic{pydantic}")
+    session.run("pytest", "--verbose")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ flake8-print
 httpx
 nbsphinx
 netCDF4
+nox
 pooch
 pre-commit
 pylint

--- a/xpublish_edr/plugin.py
+++ b/xpublish_edr/plugin.py
@@ -33,7 +33,7 @@ class CfEdrPlugin(Plugin):
     OGC EDR compatible endpoints for Xpublish datasets
     """
 
-    name = "cf_edr"
+    name: str = "cf_edr"
 
     app_router_prefix: str = "/edr"
     app_router_tags: List[str] = ["edr"]


### PR DESCRIPTION
Adds Pydantic v1 and v2 to the test matrix to make sure we stay backwards compatible and a nox config to test against the Github Actions test matrix.