### PR TITLE
chore: add uvicorn[standard] to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,7 @@ setuptools_scm
 sphinx
 twine
 uvicorn[standard]
+uvloop
 watchfiles
 websockets
 wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,8 @@ ruff
 setuptools_scm
 sphinx
 twine
+uvicorn[standard]
+websockets
 wheel
 xarray
 xpublish

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,7 @@ setuptools_scm
 sphinx
 twine
 uvicorn[standard]
+watchfiles
 websockets
 wheel
 xarray

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ ruff
 setuptools_scm
 sphinx
 twine
-uvicorn [standard]
+uvicorn-standard
 wheel
 xarray
 xpublish

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,16 +19,12 @@ pytest-cov
 pytest-flake8
 pytest-github-actions-annotate-failures
 pytest-xdist
-python-dotenv
 recommonmark
 ruff
 setuptools_scm
 sphinx
 twine
-uvicorn[standard]
-uvloop; platform_system != "Windows"
-watchfiles
-websockets
+uvicorn [standard]
 wheel
 xarray
 xpublish

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ pytest-cov
 pytest-flake8
 pytest-github-actions-annotate-failures
 pytest-xdist
+python-dotenv
 recommonmark
 ruff
 setuptools_scm

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ setuptools_scm
 sphinx
 twine
 uvicorn[standard]
-uvloop
+uvloop; platform_system != "Windows"
 watchfiles
 websockets
 wheel


### PR DESCRIPTION
Adds uvicorn/websockets to the dev environment. 

Fixes the warning:

```
pkg_resources.DistributionNotFound: The 'websockets>=10.4; extra == "standard"' distribution was not found and is required by uvicorn
```