### PR TITLE
Add initial support for controlling selection interpolation scheme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ rest = xpublish.Rest(
 
 ## OGC EDR Spec Compliance
 
-This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-086r6.html) as closely as possible, adding functionality where the value is demonstrable. Below are the implementations and a listing of spec compliance:
+This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-086r6.html) where reasonable, adding functionality where the value is demonstrable. Below are the implementations and a listing of spec compliance:
 
 [8.2.1 Position query](https://docs.ogc.org/is/19-086r6/19-086r6.html#_bbda46d4-04c5-426b-bea3-230d592fe1c2)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-0
 | `z`  | ✅ | |
 | `datetime`  | ✅ | |
 | `parameter-name`  | ✅   | |
-| `crs`  | ❌ | Not currently supported |
+| `crs`  | ❌ | Not currently supported, all coordinates should be in the reference system of the queried dataset |
 | `parameter-name`  | ✅ | |
 | `f`  | ✅ | |
 | `method`  | ➕ | Optional: controls data selection. Use "nearest" for nearest neighbor selection, or "linear" for interpolated selection. Uses `nearest` if not specified |
@@ -76,7 +76,7 @@ This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-0
 | `z`  | ✅   | |
 | `datetime`  | ✅ | |
 | `parameter-name`  | ✅   | |
-| `crs`  | ❌ | Not currently supported |
+| `crs`  | ❌ | Not currently supported, all coordinates should be in the reference system of the queried dataset |
 | `parameter-name`  | ✅   | |
 | `f`  | ✅   | |
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,37 @@ rest = xpublish.Rest(
 ```
 
 
+## OGC EDR Spec Compliance
+
+This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-086r6.html) as closely as possible, adding functionality where the value is demonstrable. Below are the implementations and a listing of spec compliance:
+
+[8.2.1 Position query](https://docs.ogc.org/is/19-086r6/19-086r6.html#_bbda46d4-04c5-426b-bea3-230d592fe1c2)
+
+| Query  | Compliant | Comments
+| ------------- | ------------- | ------------- | 
+| `coords`  | ✅ | |
+| `z`  | ✅ | |
+| `datetime`  | ✅ | |
+| `parameter-name`  | ✅   | |
+| `crs`  | ❌ | Not currently supported |
+| `parameter-name`  | ✅ | |
+| `f`  | ✅ | |
+| `method`  | ➕ | Optional: controls data selection. Use "nearest" for nearest neighbor selection, or "linear" for interpolated selection. Uses `nearest` if not specified |
+
+> Any additional query parameters are assumed to be additional selections to make on the dimensions/coordinates. These queries will use the specfied selections `method`.
+
+[8.2.3 Area query](https://docs.ogc.org/is/19-086r6/19-086r6.html#_c92d1888-dc80-454f-8452-e2f070b90dcd)
+
+| Query  | Compliant | Comments
+| ------------- | ------------- | ------------- | 
+| `coords`  | ✅ | Only `POLYGON` supported currently |
+| `z`  | ✅   | |
+| `datetime`  | ✅ | |
+| `parameter-name`  | ✅   | |
+| `crs`  | ❌ | Not currently supported |
+| `parameter-name`  | ✅   | |
+| `f`  | ✅   | |
+
 ## Get in touch
 
 Report bugs, suggest features or view the source code on [GitHub](https://github.com/gulfofmaine/xpublish-edr/issues).

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ rest = xpublish.Rest(
 
 ## OGC EDR Spec Compliance
 
-This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-086r6.html) where reasonable, adding functionality where the value is demonstrable. 
+This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-086r6.html) where reasonable, adding functionality where the value is demonstrable.
 
 ### [collections](https://docs.ogc.org/is/19-086r6/19-086r6.html#_e55ba0f5-8f24-4f1b-a7e3-45775e39ef2e) and Resource Paths Support
 
-`xpublish-edr` does not currently support the `/collections/{collectionId}/query` path template described in the spec. Instead the path resource appears as `/{dataset_id}/query`. This is because of the path structure of xpublish. 
+`xpublish-edr` does not currently support the `/collections/{collectionId}/query` path template described in the spec. Instead the path resource appears as `/{dataset_id}/query`. This is because of the path structure of xpublish.
 
 In the future, when `xpublish` supports [`DataTree`](https://docs.xarray.dev/en/stable/generated/xarray.DataTree.html) it will provide a path to supporting the spec compliant `collections` resource path.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ In the future, when `xpublish` supports [`DataTree`](https://docs.xarray.dev/en/
 
 > `method` is not applicable for the coordinates of area queries, only for selecting datetime, z, or additional dimensions.
 
+For `POLYGON` coordinates, points that are located within **OR** on the polygons boundary are included in the response.
+
 ## Get in touch
 
 Report bugs, suggest features or view the source code on [GitHub](https://github.com/gulfofmaine/xpublish-edr/issues).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ rest = xpublish.Rest(
 
 ## OGC EDR Spec Compliance
 
-This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-086r6.html) where reasonable, adding functionality where the value is demonstrable. Below are the implementations and a listing of spec compliance:
+This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-086r6.html) where reasonable, adding functionality where the value is demonstrable. 
+
+### [collections](https://docs.ogc.org/is/19-086r6/19-086r6.html#_e55ba0f5-8f24-4f1b-a7e3-45775e39ef2e) and Resource Paths Support
+
+`xpublish-edr` does not currently support the `/collections/{collectionId}/query` path template described in the spec. Instead the path resource appears as `/{dataset_id}/query`. This is because of the path structure of xpublish. 
+
+In the future, when `xpublish` supports [`DataTree`](https://docs.xarray.dev/en/stable/generated/xarray.DataTree.html) it will provide a path to supporting the spec compliant `collections` resource path.
+
+### Supported Queries
 
 [8.2.1 Position query](https://docs.ogc.org/is/19-086r6/19-086r6.html#_bbda46d4-04c5-426b-bea3-230d592fe1c2)
 
@@ -79,6 +87,9 @@ This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-0
 | `crs`  | ❌ | Not currently supported, all coordinates should be in the reference system of the queried dataset |
 | `parameter-name`  | ✅   | |
 | `f`  | ✅   | |
+| `method`  | ➕ | Optional: controls data selection. Use "nearest" for nearest neighbor selection, or "linear" for interpolated selection. Uses `nearest` if not specified |
+
+> `method` is not applicable for the coordinates of area queries, only for selecting datetime, z, or additional dimensions.
 
 ## Get in touch
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-0
 [8.2.1 Position query](https://docs.ogc.org/is/19-086r6/19-086r6.html#_bbda46d4-04c5-426b-bea3-230d592fe1c2)
 
 | Query  | Compliant | Comments
-| ------------- | ------------- | ------------- | 
+| ------------- | ------------- | ------------- |
 | `coords`  | ✅ | |
 | `z`  | ✅ | |
 | `datetime`  | ✅ | |
@@ -66,12 +66,12 @@ This package attempts to follow [the spec](https://docs.ogc.org/is/19-086r6/19-0
 | `f`  | ✅ | |
 | `method`  | ➕ | Optional: controls data selection. Use "nearest" for nearest neighbor selection, or "linear" for interpolated selection. Uses `nearest` if not specified |
 
-> Any additional query parameters are assumed to be additional selections to make on the dimensions/coordinates. These queries will use the specfied selections `method`.
+> Any additional query parameters are assumed to be additional selections to make on the dimensions/coordinates. These queries will use the specified selections `method`.
 
 [8.2.3 Area query](https://docs.ogc.org/is/19-086r6/19-086r6.html#_c92d1888-dc80-454f-8452-e2f070b90dcd)
 
 | Query  | Compliant | Comments
-| ------------- | ------------- | ------------- | 
+| ------------- | ------------- | ------------- |
 | `coords`  | ✅ | Only `POLYGON` supported currently |
 | `z`  | ✅   | |
 | `datetime`  | ✅ | |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 geopandas
+scipy
 shapely
 xarray
 xpublish>=0.3.0,<0.4.0

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -170,6 +170,26 @@ def test_select_position_regular_xy_multi(regular_xy_dataset):
     )
 
 
+def test_select_position_regular_xy_multi_interpolate(regular_xy_dataset):
+    points = MultiPoint([(202, 45), (205, 48)])
+    ds = select_by_position(regular_xy_dataset, points, method="linear")
+
+    assert ds is not None, "Dataset was not returned"
+    assert "air" in ds, "Dataset does not contain the air variable"
+    assert "lat" in ds, "Dataset does not contain the lat variable"
+    assert "lon" in ds, "Dataset does not contain the lon variable"
+
+    npt.assert_array_equal(ds["lat"], [45.0, 48.0]), "Latitude is incorrect"
+    npt.assert_array_equal(ds["lon"], [202.0, 205.0]), "Longitude is incorrect"
+    (
+        npt.assert_array_almost_equal(
+            ds["air"].isel(time=2).values,
+            [279.0, 278.2],
+        ),
+        "Temperature is incorrect",
+    )
+
+
 def test_select_area_regular_xy(regular_xy_dataset):
     polygon = Point(204, 44).buffer(5)
     ds = select_by_area(regular_xy_dataset, polygon)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -42,6 +42,7 @@ def test_select_query(regular_xy_dataset):
         coords="POINT(200 45)",
         datetime="2013-01-01T06:00:00/2013-01-01T12:00:00",
         parameters="air,time",
+        method="nearest",
     )
 
     ds = query.select(regular_xy_dataset, query_params)
@@ -56,6 +57,25 @@ def test_select_query(regular_xy_dataset):
         "Dataset shape is incorrect",
     )
     assert ds["air"].shape == (2, 25, 53), "Dataset shape is incorrect"
+
+    query = EDRQuery(
+        coords="POINT(203 46)",
+        datetime="2013-01-01T08:00:00",
+        parameters="air,time",
+        method="linear",
+    )
+
+    ds = query.select(regular_xy_dataset, query_params)
+    (
+        npt.assert_array_equal(
+            ds["time"],
+            np.array(
+                ["2013-01-01T08:00:00"],
+                dtype="datetime64[ns]",
+            ),
+        ),
+        "Time is incorrect",
+    )
 
 
 def test_select_query_error(regular_xy_dataset):
@@ -88,6 +108,15 @@ def test_select_query_error(regular_xy_dataset):
     with pytest.raises(KeyError):
         query.select(regular_xy_dataset, {})
 
+    with pytest.raises(ValueError):
+        query = EDRQuery(
+            coords="POINT(200 45)",
+            datetime="2013-01-01T06:00:00",
+            parameters="air",
+            z="100",
+            method="foo",
+        )
+
 
 def test_select_position_regular_xy(regular_xy_dataset):
     point = Point((204, 44))
@@ -105,6 +134,22 @@ def test_select_position_regular_xy(regular_xy_dataset):
     npt.assert_approx_equal(ds["air"][-1], 279.19), "Temperature is incorrect"
 
 
+def test_select_position_regular_xy_interpolate(regular_xy_dataset):
+    point = Point((204, 44))
+    ds = select_by_position(regular_xy_dataset, point, method="linear")
+
+    assert ds is not None, "Dataset was not returned"
+    assert "air" in ds, "Dataset does not contain the air variable"
+    assert "lat" in ds, "Dataset does not contain the lat variable"
+    assert "lon" in ds, "Dataset does not contain the lon variable"
+
+    assert ds["air"].shape == ds["time"].shape, "Dataset shape is incorrect"
+    npt.assert_array_equal(ds["lat"], 44.0), "Latitude is incorrect"
+    npt.assert_array_equal(ds["lon"], 204.0), "Longitude is incorrect"
+    npt.assert_approx_equal(ds["air"][0], 281.376), "Temperature is incorrect"
+    npt.assert_approx_equal(ds["air"][-1], 279.87), "Temperature is incorrect"
+
+
 def test_select_position_regular_xy_multi(regular_xy_dataset):
     points = MultiPoint([(202, 45), (205, 48)])
     ds = select_by_position(regular_xy_dataset, points)
@@ -116,10 +161,13 @@ def test_select_position_regular_xy_multi(regular_xy_dataset):
 
     npt.assert_array_equal(ds["lat"], [45.0, 47.5]), "Latitude is incorrect"
     npt.assert_array_equal(ds["lon"], [202.5, 205.0]), "Longitude is incorrect"
-    npt.assert_array_equal(
-        ds["air"].isel(time=2).values,
-        [279.1, 278.6],
-    ), "Temperature is incorrect"
+    (
+        npt.assert_array_equal(
+            ds["air"].isel(time=2).values,
+            [279.1, 278.6],
+        ),
+        "Temperature is incorrect",
+    )
 
 
 def test_select_area_regular_xy(regular_xy_dataset):

--- a/xpublish_edr/geometry/position.py
+++ b/xpublish_edr/geometry/position.py
@@ -3,6 +3,7 @@ Handle selection and formatting for position queries
 """
 
 from __future__ import annotations
+
 from typing import Literal
 
 import numpy as np

--- a/xpublish_edr/geometry/position.py
+++ b/xpublish_edr/geometry/position.py
@@ -26,9 +26,9 @@ def select_by_position(
         raise NotImplementedError("Only 1D coordinates are supported")
 
     if isinstance(point, shapely.Point):
-        return _select_by_position_regular_xy_grid(ds, point)
+        return _select_by_position_regular_xy_grid(ds, point, method)
     elif isinstance(point, shapely.MultiPoint):
-        return _select_by_multiple_positions_regular_xy_grid(ds, point)
+        return _select_by_multiple_positions_regular_xy_grid(ds, point, method)
     else:
         raise ValueError(
             f"Invalid point type {point.geom_type}, must be Point or MultiPoint",

--- a/xpublish_edr/geometry/position.py
+++ b/xpublish_edr/geometry/position.py
@@ -3,6 +3,7 @@ Handle selection and formatting for position queries
 """
 
 from __future__ import annotations
+from typing import Literal
 
 import numpy as np
 import shapely
@@ -14,6 +15,7 @@ from xpublish_edr.geometry.common import VECTORIZED_DIM, is_regular_xy_coords
 def select_by_position(
     ds: xr.Dataset,
     point: shapely.Point | shapely.MultiPoint,
+    method: Literal["nearest", "linear"] = "nearest",
 ) -> xr.Dataset:
     """
     Return a dataset with the position nearest to the given coordinates
@@ -35,17 +37,22 @@ def select_by_position(
 def _select_by_position_regular_xy_grid(
     ds: xr.Dataset,
     point: shapely.Point,
+    method: Literal["nearest", "linear"] = "nearest",
 ) -> xr.Dataset:
     """
     Return a dataset with the position nearest to the given coordinates
     """
     # Find the nearest X and Y coordinates to the point
-    return ds.cf.sel(X=point.x, Y=point.y, method="nearest")
+    if method == "nearest":
+        return ds.cf.sel(X=point.x, Y=point.y, method=method)
+    else:
+        return ds.cf.interp(X=point.x, Y=point.y, method=method)
 
 
 def _select_by_multiple_positions_regular_xy_grid(
     ds: xr.Dataset,
     points: shapely.MultiPoint,
+    method: Literal["nearest", "linear"] = "nearest",
 ) -> xr.Dataset:
     """
     Return a dataset with the positions nearest to the given coordinates
@@ -54,4 +61,7 @@ def _select_by_multiple_positions_regular_xy_grid(
     x, y = np.array(list(zip(*[(point.x, point.y) for point in points.geoms])))
     sel_x = xr.Variable(data=x, dims=VECTORIZED_DIM)
     sel_y = xr.Variable(data=y, dims=VECTORIZED_DIM)
-    return ds.cf.sel(X=sel_x, Y=sel_y, method="nearest")
+    if method == "nearest":
+        return ds.cf.sel(X=sel_x, Y=sel_y, method=method)
+    else:
+        return ds.cf.interp(X=sel_x, Y=sel_y, method=method)

--- a/xpublish_edr/plugin.py
+++ b/xpublish_edr/plugin.py
@@ -91,7 +91,7 @@ class CfEdrPlugin(Plugin):
             Extra selecting/slicing parameters can be provided as extra query parameters
             """
             try:
-                ds = select_by_position(dataset, query.geometry)
+                ds = select_by_position(dataset, query.geometry, query.method)
             except KeyError:
                 raise HTTPException(
                     status_code=404,


### PR DESCRIPTION
This PR adds an optional `method` query param that controls the selection method used for returning data from an EDR requests. 

The two options are "nearest" which uses `xarray`s built in `sel` method (the current behavior) and "linear" which will use `xarray`s `interp` method. If no `method` param is provided then "nearest" is used. 

This is used for all query areas as applicable. For arbitrary dimensions, if interpolating fails, it will fall back to the default nearest neighbor methodology. 