### PR TITLE
Switch order of operations so axes are not filtered by parameter subsetting

### DIFF
--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -361,7 +361,6 @@ def test_cf_area_query(cf_client, cf_dataset):
     ), "DataArray long_name should be set as parameter description"
 
     air_range = data["ranges"]["air"]
-    print(air_range)
 
     assert air_range["type"] == "NdArray", "Response range should be a NdArray"
     assert air_range["dataType"] == "float", "Air dataType should be floats"

--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -104,7 +104,9 @@ def test_cf_position_query(cf_client, cf_dataset):
 def test_cf_position_csv(cf_client):
     x = 204
     y = 44
-    response = cf_client.get(f"/datasets/air/edr/position?coords=POINT({x} {y})&f=csv")
+    response = cf_client.get(
+        f"/datasets/air/edr/position?coords=POINT({x} {y})&f=csv&parameter-name=air"
+    )
 
     assert response.status_code == 200, "Response did not return successfully"
     assert (
@@ -215,7 +217,7 @@ def test_cf_position_geojson(cf_client):
     x = 204
     y = 44
     response = cf_client.get(
-        f"/datasets/air/edr/position?coords=POINT({x} {y})&f=geojson",
+        f"/datasets/air/edr/position?coords=POINT({x} {y})&f=geojson&parameter-name=air",
     )
 
     assert response.status_code == 200, "Response did not return successfully"

--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -105,7 +105,7 @@ def test_cf_position_csv(cf_client):
     x = 204
     y = 44
     response = cf_client.get(
-        f"/datasets/air/edr/position?coords=POINT({x} {y})&f=csv&parameter-name=air"
+        f"/datasets/air/edr/position?coords=POINT({x} {y})&f=csv&parameter-name=air",
     )
 
     assert response.status_code == 200, "Response did not return successfully"

--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -334,10 +334,10 @@ def test_cf_area_query(cf_client, cf_dataset):
     axes = data["domain"]["axes"]
 
     assert axes["x"] == {
-        "values": [202.5, 202.5, 202.5, 205.0, 205.0, 205.0, 207.5, 207.5, 207.5],
+        "values": [202.5, 205.0, 207.5, 202.5, 205.0, 207.5, 202.5, 205.0, 207.5],
     }, "Did not select nearby x coordinates within the polygon"
     assert axes["y"] == {
-        "values": [47.5, 45.0, 42.5, 47.5, 45.0, 42.5, 47.5, 45.0, 42.5],
+        "values": [47.5, 47.5, 47.5, 45.0, 45.0, 45.0, 42.5, 42.5, 42.5],
     }, "Did not select a nearby y coordinates within the polygon"
 
     assert (
@@ -361,6 +361,7 @@ def test_cf_area_query(cf_client, cf_dataset):
     ), "DataArray long_name should be set as parameter description"
 
     air_range = data["ranges"]["air"]
+    print(air_range)
 
     assert air_range["type"] == "NdArray", "Response range should be a NdArray"
     assert air_range["dataType"] == "float", "Air dataType should be floats"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -203,6 +203,10 @@ def test_select_area_regular_xy(regular_xy_dataset):
     assert ds["lat"].shape == (13,), "Latitude shape is incorrect"
     assert ds["lon"].shape == (13,), "Longitude shape is incorrect"
 
+    print(ds["lat"].values)
+    print(ds["lon"].values)
+    print(ds["air"].isel(time=0).values)
+
     (
         npt.assert_array_equal(np.unique(ds["lat"]), [40.0, 42.5, 45.0, 47.5]),
         "Latitude is incorrect",
@@ -216,19 +220,19 @@ def test_select_area_regular_xy(regular_xy_dataset):
             ds["air"].isel(time=0),
             np.array(
                 [
+                    279.0,
+                    279.0,
+                    278.9,
                     280.0,
-                    282.79,
-                    284.6,
-                    279.0,
                     280.7,
-                    283.2,
-                    284.9,
-                    279.0,
                     280.2,
-                    282.6,
-                    284.2,
                     279.6,
+                    282.79,
+                    283.2,
+                    282.6,
                     281.9,
+                    284.9,
+                    284.2,
                 ],
             ),
         ),

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -203,10 +203,6 @@ def test_select_area_regular_xy(regular_xy_dataset):
     assert ds["lat"].shape == (13,), "Latitude shape is incorrect"
     assert ds["lon"].shape == (13,), "Longitude shape is incorrect"
 
-    print(ds["lat"].values)
-    print(ds["lon"].values)
-    print(ds["air"].isel(time=0).values)
-
     (
         npt.assert_array_equal(np.unique(ds["lat"]), [40.0, 42.5, 45.0, 47.5]),
         "Latitude is incorrect",

--- a/xpublish_edr/geometry/area.py
+++ b/xpublish_edr/geometry/area.py
@@ -40,10 +40,11 @@ def _select_area_regular_xy_grid(
     mask = shapely.intersects_xy(polygon, pts[0], pts[1])
 
     # Find the x and y indices that have any points within the polygon
-    x_inds, y_inds = np.nonzero(mask)
+    y_inds, x_inds = np.nonzero(mask)
     x_sel = xr.Variable(data=x_inds, dims=VECTORIZED_DIM)
     y_sel = xr.Variable(data=y_inds, dims=VECTORIZED_DIM)
 
     # Apply the mask and vectorize to a 1d collection of points
     ds_sub = ds.cf.isel(X=x_sel, Y=y_sel)
+
     return ds_sub

--- a/xpublish_edr/plugin.py
+++ b/xpublish_edr/plugin.py
@@ -91,7 +91,17 @@ class CfEdrPlugin(Plugin):
             Extra selecting/slicing parameters can be provided as extra query parameters
             """
             try:
-                ds = select_by_position(dataset, query.geometry, query.method)
+                ds = query.select(dataset, dict(request.query_params))
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Error selecting from query: {e.args[0]}",
+                )
+
+            logger.debug(f"Dataset filtered by query params {ds}")
+
+            try:
+                ds = select_by_position(ds, query.geometry, query.method)
             except KeyError:
                 raise HTTPException(
                     status_code=404,
@@ -101,16 +111,6 @@ class CfEdrPlugin(Plugin):
             logger.debug(
                 f"Dataset filtered by position ({query.geometry}): {ds}",
             )
-
-            try:
-                ds = query.select(ds, dict(request.query_params))
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Error selecting from query: {e.args[0]}",
-                )
-
-            logger.debug(f"Dataset filtered by query params {ds}")
 
             if query.format:
                 try:
@@ -138,6 +138,16 @@ class CfEdrPlugin(Plugin):
             Extra selecting/slicing parameters can be provided as extra query parameters
             """
             try:
+                ds = query.select(dataset, dict(request.query_params))
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Error selecting from query: {e.args[0]}",
+                )
+
+            logger.debug(f"Dataset filtered by query params {ds}")
+
+            try:
                 ds = select_by_area(dataset, query.geometry)
             except KeyError:
                 raise HTTPException(
@@ -146,16 +156,6 @@ class CfEdrPlugin(Plugin):
                 )
 
             logger.debug(f"Dataset filtered by polygon {query.geometry.boundary}: {ds}")
-
-            try:
-                ds = query.select(ds, dict(request.query_params))
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Error selecting from query: {e.args[0]}",
-                )
-
-            logger.debug(f"Dataset filtered by query params {ds}")
 
             if query.format:
                 try:

--- a/xpublish_edr/plugin.py
+++ b/xpublish_edr/plugin.py
@@ -148,7 +148,7 @@ class CfEdrPlugin(Plugin):
             logger.debug(f"Dataset filtered by query params {ds}")
 
             try:
-                ds = select_by_area(dataset, query.geometry)
+                ds = select_by_area(ds, query.geometry)
             except KeyError:
                 raise HTTPException(
                     status_code=404,


### PR DESCRIPTION
Closes #56 

Bonus: Fix bad bug in area unpacking coordinates incorrectly 