### PR TITLE
Fix geotiff coord order

### DIFF
--- a/xpublish_edr/formats/to_geotiff.py
+++ b/xpublish_edr/formats/to_geotiff.py
@@ -49,6 +49,7 @@ def to_geotiff(ds: xr.Dataset) -> Response:
     x_coord = axes["X"][0]
     y_coord = axes["Y"][0]
     ds = ds.rio.set_spatial_dims(x_dim=x_coord, y_dim=y_coord, inplace=True)
+    ds = ds.transpose(..., y_coord, x_coord)
 
     # Create in-memory GeoTIFF
     memfile = io.BytesIO()


### PR DESCRIPTION
rasterio requires dim s to be `(y,x)` order