### PR TITLE
Dont reproject for metadata queries

### DIFF
--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -140,6 +140,21 @@ def test_cf_metadata_query(cf_client):
     assert "lon" not in data["parameter_names"], "lon should not be present"
 
 
+def test_cf_metadata_rotated_lat_lon(cf_client):
+    response = cf_client.get("/datasets/temp/edr/")
+    assert response.status_code == 200, "Response did not return successfully"
+    data = response.json()
+
+    # We want to verify that the extents are in the correct crs and that both the rotated
+    # crs and the lat lng crs are present
+    assert data["extent"]["spatial"]["crs"] != "EPSG:4326", "Spatial CRS is incorrect"
+    npt.assert_allclose(
+        data["extent"]["spatial"]["bbox"],
+        [[17.935, 21.615, 18.155, 21.835]],
+        atol=1e-6,
+    )
+
+
 def test_cf_metadata_query_temp_smoke_test(cf_client):
     response = cf_client.get("/datasets/temp/edr/")
     assert response.status_code == 200, "Response did not return successfully"

--- a/xpublish_edr/metadata.py
+++ b/xpublish_edr/metadata.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, Field
 from xpublish_edr.geometry.common import (
     DEFAULT_CRS,
     dataset_crs,
-    project_dataset,
     spatial_bounds,
 )
 
@@ -415,11 +414,7 @@ def collection_metadata(ds: xr.Dataset, output_formats: list[str]) -> Collection
 
     crs = dataset_crs(ds)
 
-    # We will use the dataset's CRS as the default CRS, but use 4326 for the extents
-    # since it is always available
-    projected_ds = project_dataset(ds, DEFAULT_CRS)
-
-    extents = extent(projected_ds, crs)
+    extents = extent(ds, crs)
 
     parameters = extract_parameters(ds)
 


### PR DESCRIPTION
We support all crs, so no need to provide extents outside the crs of the dataset with the metadata

This was causing major performance issues when fethcing metadata because it reprojects the entire dataset