### PR TITLE
Convert float16 arrays for netcdf and geotiff exports

### DIFF
--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -13,6 +13,9 @@ from xpublish_edr import CfEdrPlugin
 def cf_air_dataset():
     from cf_xarray.datasets import airds
 
+    # Create a float16 version of the air variable
+    airds["air_float16"] = airds["air"].astype("float16")
+
     return airds
 
 
@@ -793,7 +796,8 @@ def test_cf_cube_query_csv(cf_client, cf_air_dataset):
         assert key in csv_data[0], f"column {key} should be in the header"
 
 
-def test_cf_cube_query_geotiff_latlng_grid(cf_client, cf_air_dataset):
+@pytest.mark.parametrize("parameter", ["air", "air_float16"])
+def test_cf_cube_query_geotiff_latlng_grid(cf_client, cf_air_dataset, parameter):
     import io
 
     import rioxarray
@@ -802,7 +806,7 @@ def test_cf_cube_query_geotiff_latlng_grid(cf_client, cf_air_dataset):
 
     # Test with multiple time steps
     response = cf_client.get(
-        f"/datasets/air/edr/cube?bbox={bbox}&parameter-name=air&f=geotiff",
+        f"/datasets/air/edr/cube?bbox={bbox}&parameter-name={parameter}&f=geotiff",
     )
     assert response.status_code == 200, "Response should have returned a 200"
     assert (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import numpy as np
+import xarray as xr
+
+from xpublish_edr.utils import to_compat_da_dtype
+
+
+def test_to_compat_da_dtype():
+    # Test float16 conversion to float32
+    da_float16 = xr.DataArray([1.0, 2.0, 3.0]).astype(np.float16)
+    result = to_compat_da_dtype(da_float16)
+    assert result.dtype == np.float32
+
+    # Test float32 remains unchanged
+    da_float32 = xr.DataArray([1.0, 2.0, 3.0]).astype(np.float32)
+    result = to_compat_da_dtype(da_float32)
+    assert result.dtype == np.float32
+
+    # Test int types remain unchanged
+    da_int = xr.DataArray([1, 2, 3]).astype(np.int32)
+    result = to_compat_da_dtype(da_int)
+    assert result.dtype == np.int32

--- a/xpublish_edr/formats/to_netcdf.py
+++ b/xpublish_edr/formats/to_netcdf.py
@@ -8,11 +8,16 @@ from tempfile import TemporaryDirectory
 import xarray as xr
 from fastapi import Response
 
+from xpublish_edr.utils import to_compat_da_dtype
+
 
 def to_netcdf(ds: xr.Dataset):
     """Return a NetCDF response from a dataset"""
     with TemporaryDirectory() as tmpdir:
         path = Path(tmpdir) / "data.nc"
+
+        # Float16 is not supported by netCDF4
+        ds = ds.map(to_compat_da_dtype)
         ds.to_netcdf(path)
 
         with path.open("rb") as f:

--- a/xpublish_edr/utils.py
+++ b/xpublish_edr/utils.py
@@ -1,0 +1,16 @@
+"""Data utilities for xpublish-edr processing"""
+
+import numpy as np
+import xarray as xr
+
+
+def to_compat_da_dtype(da: xr.DataArray) -> xr.DataArray:
+    """Ensures data arrays are valid for rasterio + gdal + netcdf
+
+    Currently float16 is not supported until rasterio ships gdal 3.11, so we need to cast to float32
+
+    NetCDF does not support float16 either, so we need to cast to float32
+    """
+    if da.dtype.kind == "f" and da.dtype.itemsize < 4:
+        da = da.astype(np.float32)
+    return da


### PR DESCRIPTION
current netcdf conversion doesnt support float16 and neither does the latest version of rasterio. This will change when rasterio syncs with gdal 3.11