### PR TITLE
Fix PyPI test failures by installing GDAL

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install GDAL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdal-bin libgdal-dev
+
       # - name: Get tags
       #   run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 


### PR DESCRIPTION
One of Geopandas dependencies requires GDAL, so the wheel install test 
was failing in the PyPI tests.
https://github.com/xpublish-community/xpublish-edr/actions/runs/19649011088/job/56271203630?pr=90#step:7:152