### PR TITLE
Ensure indexes exist for metadata and selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ import xpublish
 from xpublish.routers import base_router, zarr_router
 from xpublish_edr.cf_edr_router import cf_edr_router
 
-
 ds = xr.open_dataset("dataset.nc")
 
 rest = xpublish.Rest(

--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -938,7 +938,7 @@ def test_cf_generic_extents_band_and_step():
     )
 
     band = xr.DataArray([1, 2], dims=("band",))
-    step = xr.DataArray(pd.to_timedelta([0, "6h", "12h"]), dims=("step",))
+    step = xr.DataArray(pd.to_timedelta(["0h", "6h", "12h"]), dims=("step",))
 
     data = xr.DataArray(
         np.arange(3 * 2 * 2 * 3).reshape(3, 2, 2, 3).astype(float),
@@ -994,7 +994,7 @@ def test_cf_generic_extents_band_and_step():
     assert ext["band"]["interval"] == [1, 2]
 
     # step: timedelta values as ISO 8601 durations and proper interval
-    expected_steps = [pd.Timedelta(x).isoformat() for x in [0, "6h", "12h"]]
+    expected_steps = [pd.Timedelta(x).isoformat() for x in ["0h", "6h", "12h"]]
     assert ext["step"]["values"] == expected_steps
     assert ext["step"]["interval"] == [expected_steps[0], expected_steps[-1]]
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -218,7 +218,7 @@ def test_select_query_error(regular_xy_dataset):
         z="100",
     )
 
-    with pytest.raises(ValueError, match="Cannot select on Z axis"):
+    with pytest.raises(ValueError, match="Cannot select on Z axis via cf_xarray"):
         query.select(regular_xy_dataset, {})
 
     with pytest.raises(ValueError):
@@ -593,7 +593,7 @@ def test_datetime_query_error_non_indexed(dataset_with_non_indexed_axes):
         datetime="2024-01-01T06:00:00",
         parameters="temperature",
     )
-    with pytest.raises(ValueError, match="Cannot select on T axis"):
+    with pytest.raises(ValueError, match="Cannot select on T axis via cf_xarray"):
         query.select(dataset_with_non_indexed_axes, {})
 
 
@@ -604,5 +604,5 @@ def test_z_query_error_non_indexed(dataset_with_non_indexed_axes):
         z="8500",
         parameters="temperature",
     )
-    with pytest.raises(ValueError, match="Cannot select on Z axis"):
+    with pytest.raises(ValueError, match="Cannot select on Z axis via cf_xarray"):
         query.select(dataset_with_non_indexed_axes, {})

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -526,7 +526,9 @@ def test_temporal_extent_skips_non_indexed(dataset_with_non_indexed_axes):
     from xpublish_edr.metadata import temporal_extent
 
     extent = temporal_extent(dataset_with_non_indexed_axes)
-    assert extent is None, "Should not report temporal extent for non-indexed T coordinate"
+    assert (
+        extent is None
+    ), "Should not report temporal extent for non-indexed T coordinate"
 
 
 def test_vertical_extent_skips_non_indexed(dataset_with_non_indexed_axes):
@@ -534,7 +536,9 @@ def test_vertical_extent_skips_non_indexed(dataset_with_non_indexed_axes):
     from xpublish_edr.metadata import vertical_extent
 
     extent = vertical_extent(dataset_with_non_indexed_axes)
-    assert extent is None, "Should not report vertical extent for non-indexed Z coordinate"
+    assert (
+        extent is None
+    ), "Should not report vertical extent for non-indexed Z coordinate"
 
 
 def test_generic_extents_includes_indexed_dims_from_non_indexed_axes(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -243,8 +243,12 @@ def test_select_position_regular_xy(regular_xy_dataset):
     assert ds["air"].shape == (2920, 1, 1), "Dataset shape is incorrect"
     npt.assert_array_equal(ds["lat"], 45.0), "Latitude is incorrect"
     npt.assert_array_equal(ds["lon"], 205.0), "Longitude is incorrect"
-    npt.assert_approx_equal(ds["air"].isel(time=0).values.item(), 280.2), "Temperature is incorrect"
-    npt.assert_approx_equal(ds["air"].isel(time=-1).values.item(), 279.19), "Temperature is incorrect"
+    npt.assert_approx_equal(
+        ds["air"].isel(time=0).values.item(), 280.2,
+    ), "Temperature is incorrect"
+    npt.assert_approx_equal(
+        ds["air"].isel(time=-1).values.item(), 279.19,
+    ), "Temperature is incorrect"
 
 
 def test_select_position_projected_xy(projected_xy_dataset):
@@ -294,8 +298,12 @@ def test_select_position_regular_xy_interpolate(regular_xy_dataset):
     assert ds["air"].shape == (2920, 1, 1), "Dataset shape is incorrect"
     npt.assert_array_equal(ds["lat"], 44.0), "Latitude is incorrect"
     npt.assert_array_equal(ds["lon"], 204.0), "Longitude is incorrect"
-    npt.assert_approx_equal(ds["air"].isel(time=0).values.item(), 281.376), "Temperature is incorrect"
-    npt.assert_approx_equal(ds["air"].isel(time=-1).values.item(), 279.87), "Temperature is incorrect"
+    npt.assert_approx_equal(
+        ds["air"].isel(time=0).values.item(), 281.376,
+    ), "Temperature is incorrect"
+    npt.assert_approx_equal(
+        ds["air"].isel(time=-1).values.item(), 279.87,
+    ), "Temperature is incorrect"
 
 
 def test_select_position_regular_xy_multi(regular_xy_dataset):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -218,7 +218,7 @@ def test_select_query_error(regular_xy_dataset):
         z="100",
     )
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError, match="no vertical dimension"):
         query.select(regular_xy_dataset, {})
 
     with pytest.raises(ValueError):
@@ -480,3 +480,116 @@ def test_select_string_dim(regular_xy_dataset_with_string_dim):
         },
     )
     assert ds["air"].shape == (1, 25, 53), "Dataset shape is incorrect"
+
+
+@pytest.fixture(scope="function")
+def dataset_with_non_indexed_axes():
+    """Creates a dataset with non-indexed CF axis coordinates (like GFS forecast)"""
+    init_times = pd.date_range("2024-01-01", periods=4, freq="6h")
+    lead_times = pd.to_timedelta([0, 1, 2, 3], unit="h")
+    levels = [1000, 850, 500]
+
+    ds = xr.Dataset(
+        coords={
+            "init_time": init_times,
+            "lead_time": lead_times,
+            "level": levels,
+            "lat": np.arange(40, 45, dtype=float),
+            "lon": np.arange(200, 205, dtype=float),
+        },
+        data_vars={
+            "temperature": (
+                ("init_time", "lead_time", "level", "lat", "lon"),
+                np.random.rand(4, 4, 3, 5, 5),
+            ),
+        },
+    )
+    # Add CF attributes for lat/lon
+    ds.lat.attrs["axis"] = "Y"
+    ds.lon.attrs["axis"] = "X"
+
+    # Add non-indexed 2D coordinates with CF attributes
+    ds = ds.assign_coords(valid_time=ds.init_time + ds.lead_time)
+    ds.valid_time.attrs["axis"] = "T"
+    ds.valid_time.attrs["standard_name"] = "time"
+
+    # Add non-indexed Z coordinate
+    ds = ds.assign_coords(altitude=("level", [10000, 8500, 5000]))
+    ds.altitude.attrs["axis"] = "Z"
+    ds.altitude.attrs["positive"] = "up"
+
+    return ds
+
+
+def test_temporal_extent_skips_non_indexed(dataset_with_non_indexed_axes):
+    """Temporal extent should be None when T axis is not indexed"""
+    from xpublish_edr.metadata import temporal_extent
+
+    extent = temporal_extent(dataset_with_non_indexed_axes)
+    assert extent is None, "Should not report temporal extent for non-indexed T coordinate"
+
+
+def test_vertical_extent_skips_non_indexed(dataset_with_non_indexed_axes):
+    """Vertical extent should be None when Z axis is not indexed"""
+    from xpublish_edr.metadata import vertical_extent
+
+    extent = vertical_extent(dataset_with_non_indexed_axes)
+    assert extent is None, "Should not report vertical extent for non-indexed Z coordinate"
+
+
+def test_generic_extents_includes_indexed_dims_from_non_indexed_axes(
+    dataset_with_non_indexed_axes,
+):
+    """init_time, lead_time, and level should appear because T and Z axes are not indexed"""
+    from xpublish_edr.metadata import generic_extents
+
+    extents = generic_extents(dataset_with_non_indexed_axes)
+    assert extents is not None
+    assert "init_time" in extents, "init_time should be in generic extents"
+    assert "lead_time" in extents, "lead_time should be in generic extents"
+    assert "level" in extents, "level should be in generic extents"
+
+
+def test_generic_extents_excludes_non_indexed_dims():
+    """Dimensions without indexes should not appear in generic extents"""
+    from xpublish_edr.metadata import generic_extents
+
+    # Create dataset with a dimension that has no index
+    ds = xr.Dataset(
+        data_vars={
+            "data": (("x", "y", "ensemble"), np.random.rand(5, 5, 10)),
+        },
+        coords={
+            "x": np.arange(5, dtype=float),
+            "y": np.arange(5, dtype=float),
+            # "ensemble" has no coordinate, so no index
+        },
+    )
+    ds.x.attrs["axis"] = "X"
+    ds.y.attrs["axis"] = "Y"
+
+    extents = generic_extents(ds)
+    # ensemble should not be in extents because it has no index
+    assert extents is None or "ensemble" not in extents
+
+
+def test_datetime_query_error_non_indexed(dataset_with_non_indexed_axes):
+    """Datetime queries should raise clear error for non-indexed T coordinate"""
+    query = EDRPositionQuery(
+        coords="POINT(202 42)",
+        datetime="2024-01-01T06:00:00",
+        parameters="temperature",
+    )
+    with pytest.raises(ValueError, match="not indexed"):
+        query.select(dataset_with_non_indexed_axes, {})
+
+
+def test_z_query_error_non_indexed(dataset_with_non_indexed_axes):
+    """Z queries should raise clear error for non-indexed Z coordinate"""
+    query = EDRPositionQuery(
+        coords="POINT(202 42)",
+        z="8500",
+        parameters="temperature",
+    )
+    with pytest.raises(ValueError, match="not indexed"):
+        query.select(dataset_with_non_indexed_axes, {})

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -244,10 +244,12 @@ def test_select_position_regular_xy(regular_xy_dataset):
     npt.assert_array_equal(ds["lat"], 45.0), "Latitude is incorrect"
     npt.assert_array_equal(ds["lon"], 205.0), "Longitude is incorrect"
     npt.assert_approx_equal(
-        ds["air"].isel(time=0).values.item(), 280.2,
+        ds["air"].isel(time=0).values.item(),
+        280.2,
     ), "Temperature is incorrect"
     npt.assert_approx_equal(
-        ds["air"].isel(time=-1).values.item(), 279.19,
+        ds["air"].isel(time=-1).values.item(),
+        279.19,
     ), "Temperature is incorrect"
 
 
@@ -299,10 +301,12 @@ def test_select_position_regular_xy_interpolate(regular_xy_dataset):
     npt.assert_array_equal(ds["lat"], 44.0), "Latitude is incorrect"
     npt.assert_array_equal(ds["lon"], 204.0), "Longitude is incorrect"
     npt.assert_approx_equal(
-        ds["air"].isel(time=0).values.item(), 281.376,
+        ds["air"].isel(time=0).values.item(),
+        281.376,
     ), "Temperature is incorrect"
     npt.assert_approx_equal(
-        ds["air"].isel(time=-1).values.item(), 279.87,
+        ds["air"].isel(time=-1).values.item(),
+        279.87,
     ), "Temperature is incorrect"
 
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -162,7 +162,7 @@ def test_select_query(regular_xy_dataset):
             "lat": np.arange(45, 47),
             "lon": np.arange(200, 202),
             "elevation": np.arange(100, 105),
-            "step": pd.timedelta_range("0 days", periods=72, freq="1H"),
+            "step": pd.timedelta_range("0 days", periods=72, freq="1h"),
         },
         data_vars={
             "air": (("lat", "lon", "elevation", "step"), np.random.rand(2, 2, 5, 72)),
@@ -178,7 +178,7 @@ def test_select_query(regular_xy_dataset):
     assert ds["air"].shape == (2, 2, 1, 11), "Dataset shape is incorrect"
     npt.assert_array_equal(
         ds["step"],
-        pd.timedelta_range("0 days", periods=11, freq="1H"),
+        pd.timedelta_range("0 days", periods=11, freq="1h"),
     )
     npt.assert_equal(ds["elevation"].values, 101)
 
@@ -186,7 +186,7 @@ def test_select_query(regular_xy_dataset):
     assert ds["air"].shape == (2, 2, 3, 1), "Dataset shape is incorrect"
     npt.assert_array_equal(
         ds["step"],
-        pd.timedelta_range("1 hours", periods=1, freq="1H"),
+        pd.timedelta_range("1 hours", periods=1, freq="1h"),
     )
     npt.assert_equal(ds["elevation"].values, np.array([101, 102, 103]))
 
@@ -243,8 +243,8 @@ def test_select_position_regular_xy(regular_xy_dataset):
     assert ds["air"].shape == (2920, 1, 1), "Dataset shape is incorrect"
     npt.assert_array_equal(ds["lat"], 45.0), "Latitude is incorrect"
     npt.assert_array_equal(ds["lon"], 205.0), "Longitude is incorrect"
-    npt.assert_approx_equal(ds["air"][0], 280.2), "Temperature is incorrect"
-    npt.assert_approx_equal(ds["air"][-1], 279.19), "Temperature is incorrect"
+    npt.assert_approx_equal(ds["air"].isel(time=0).values.item(), 280.2), "Temperature is incorrect"
+    npt.assert_approx_equal(ds["air"].isel(time=-1).values.item(), 279.19), "Temperature is incorrect"
 
 
 def test_select_position_projected_xy(projected_xy_dataset):
@@ -265,24 +265,21 @@ def test_select_position_projected_xy(projected_xy_dataset):
 
     projected_ds = project_dataset(ds, query.crs)
     (
-        npt.assert_approx_equal(projected_ds.cf["X"].values, 64.59063409),
+        npt.assert_approx_equal(projected_ds.cf["X"].values.item(), 64.59063409),
         "Longitude is incorrect",
     )
     (
-        npt.assert_approx_equal(projected_ds.cf["Y"].values, 66.66454929),
+        npt.assert_approx_equal(projected_ds.cf["Y"].values.item(), 66.66454929),
         "Latitude is incorrect",
     )
-    (
-        npt.assert_approx_equal(
-            projected_ds.temp.values,
-            projected_xy_dataset.sel(
-                rlon=[18.045],
-                rlat=[21.725],
-                method="nearest",
-            ).temp.values,
-        ),
-        "Temperature is incorrect",
-    )
+    npt.assert_array_almost_equal(
+        projected_ds.temp.values,
+        projected_xy_dataset.sel(
+            rlon=[18.045],
+            rlat=[21.725],
+            method="nearest",
+        ).temp.values,
+    ), "Temperature is incorrect"
 
 
 def test_select_position_regular_xy_interpolate(regular_xy_dataset):
@@ -297,8 +294,8 @@ def test_select_position_regular_xy_interpolate(regular_xy_dataset):
     assert ds["air"].shape == (2920, 1, 1), "Dataset shape is incorrect"
     npt.assert_array_equal(ds["lat"], 44.0), "Latitude is incorrect"
     npt.assert_array_equal(ds["lon"], 204.0), "Longitude is incorrect"
-    npt.assert_approx_equal(ds["air"][0], 281.376), "Temperature is incorrect"
-    npt.assert_approx_equal(ds["air"][-1], 279.87), "Temperature is incorrect"
+    npt.assert_approx_equal(ds["air"].isel(time=0).values.item(), 281.376), "Temperature is incorrect"
+    npt.assert_approx_equal(ds["air"].isel(time=-1).values.item(), 279.87), "Temperature is incorrect"
 
 
 def test_select_position_regular_xy_multi(regular_xy_dataset):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -218,7 +218,7 @@ def test_select_query_error(regular_xy_dataset):
         z="100",
     )
 
-    with pytest.raises(ValueError, match="no vertical dimension"):
+    with pytest.raises(ValueError, match="Cannot select on Z axis"):
         query.select(regular_xy_dataset, {})
 
     with pytest.raises(ValueError):
@@ -593,7 +593,7 @@ def test_datetime_query_error_non_indexed(dataset_with_non_indexed_axes):
         datetime="2024-01-01T06:00:00",
         parameters="temperature",
     )
-    with pytest.raises(ValueError, match="not indexed"):
+    with pytest.raises(ValueError, match="Cannot select on T axis"):
         query.select(dataset_with_non_indexed_axes, {})
 
 
@@ -604,5 +604,5 @@ def test_z_query_error_non_indexed(dataset_with_non_indexed_axes):
         z="8500",
         parameters="temperature",
     )
-    with pytest.raises(ValueError, match="not indexed"):
+    with pytest.raises(ValueError, match="Cannot select on Z axis"):
         query.select(dataset_with_non_indexed_axes, {})

--- a/xpublish_edr/metadata.py
+++ b/xpublish_edr/metadata.py
@@ -14,6 +14,24 @@ from xpublish_edr.geometry.common import (
 from xpublish_edr.logger import logger
 
 
+def cf_axis_is_indexed(ds: xr.Dataset, axis: str) -> bool:
+    """Check if a CF axis coordinate is indexed (queryable via selection).
+
+    Args:
+        ds: The dataset to check
+        axis: The CF axis name (e.g., "X", "Y", "Z", "T")
+
+    Returns:
+        True if the axis exists and is indexed, False otherwise
+    """
+    if axis not in ds.cf:
+        return False
+    coord = ds.cf[axis]
+    if isinstance(coord, xr.DataArray):
+        return coord.name in ds.indexes
+    return False
+
+
 class CRSDetails(BaseModel):
     """OGC EDR CRS metadata
 
@@ -291,7 +309,7 @@ def spatial_extent(ds: xr.Dataset, crs: pyproj.CRS) -> SpatialExtent:
 
 def temporal_extent(ds: xr.Dataset) -> Optional[TemporalExtent]:
     """Extract the temporal extent from the dataset into collection metadata specific format"""
-    if "T" not in ds.cf:
+    if not cf_axis_is_indexed(ds, "T"):
         return None
 
     t = pd.to_datetime(ds.cf["T"])  # type: ignore[index]
@@ -306,7 +324,7 @@ def temporal_extent(ds: xr.Dataset) -> Optional[TemporalExtent]:
 
 def vertical_extent(ds: xr.Dataset) -> Optional[VerticalExtent]:
     """Extract the vertical extent from the dataset into collection metadata specific format"""
-    if "Z" not in ds.cf:
+    if not cf_axis_is_indexed(ds, "Z"):
         return None
 
     z = ds.cf["Z"]  # type: ignore[index]
@@ -361,7 +379,8 @@ def generic_extents(ds: xr.Dataset) -> Optional[dict[str, GenericExtent]]:
     """
     excluded_dims: set[str] = set()
     for axis in ("X", "Y", "T", "Z"):
-        if axis in ds.cf:  # type: ignore[operator]
+        # Only exclude dimensions if the CF axis is actually indexed
+        if cf_axis_is_indexed(ds, axis):
             try:
                 coord = ds.cf[axis]  # type: ignore[index]
                 if isinstance(coord, xr.DataArray):
@@ -373,6 +392,9 @@ def generic_extents(ds: xr.Dataset) -> Optional[dict[str, GenericExtent]]:
     other: dict[str, GenericExtent] = {}
     for dim in ds.dims:
         if dim in excluded_dims:
+            continue
+        # Only include dimensions that are indexed (can be selected on)
+        if dim not in ds.indexes:
             continue
         try:
             # try to get a coordinate variable with same name

--- a/xpublish_edr/query.py
+++ b/xpublish_edr/query.py
@@ -66,8 +66,9 @@ class BaseEDRQuery(BaseModel):
                     ds = ds.cf.interp(Z=[self.z], method=self.method)
             except KeyError as e:
                 raise ValueError(
-                    f"Cannot select on Z axis: {e}. "
-                    f"Available indexed dimensions: {list(ds.indexes.keys())}",
+                    f"Cannot select on Z axis via cf_xarray: {e}. "
+                    f"The Z coordinate may not be indexed. "
+                    f"Indexed dimensions available for direct selection: {list(ds.indexes.keys())}",
                 ) from e
 
         if self.datetime:
@@ -86,8 +87,9 @@ class BaseEDRQuery(BaseModel):
                     )
             except KeyError as e:
                 raise ValueError(
-                    f"Cannot select on T axis: {e}. "
-                    f"Available indexed dimensions: {list(ds.indexes.keys())}",
+                    f"Cannot select on T axis via cf_xarray: {e}. "
+                    f"The T coordinate may not be indexed. "
+                    f"Indexed dimensions available for direct selection: {list(ds.indexes.keys())}",
                 ) from e
             except ValueError as e:
                 logger.error("Error with datetime", exc_info=True)

--- a/xpublish_edr/query.py
+++ b/xpublish_edr/query.py
@@ -66,7 +66,7 @@ class BaseEDRQuery(BaseModel):
             if isinstance(z_coord, xr.DataArray) and z_coord.name not in ds.indexes:
                 raise ValueError(
                     f"Vertical coordinate '{z_coord.name}' is not indexed and cannot "
-                    f"be queried. Available indexed dimensions: {list(ds.indexes.keys())}"
+                    f"be queried. Available indexed dimensions: {list(ds.indexes.keys())}",
                 )
             if self.method == "nearest":
                 ds = ds.cf.sel(Z=[self.z], method=self.method)
@@ -76,12 +76,14 @@ class BaseEDRQuery(BaseModel):
         if self.datetime:
             # Validate T axis exists and is indexed
             if "T" not in ds.cf:
-                raise ValueError("Dataset has no temporal dimension for datetime queries")
+                raise ValueError(
+                    "Dataset has no temporal dimension for datetime queries",
+                )
             t_coord = ds.cf["T"]
             if isinstance(t_coord, xr.DataArray) and t_coord.name not in ds.indexes:
                 raise ValueError(
                     f"Temporal coordinate '{t_coord.name}' is not indexed and cannot "
-                    f"be queried. Available indexed dimensions: {list(ds.indexes.keys())}"
+                    f"be queried. Available indexed dimensions: {list(ds.indexes.keys())}",
                 )
             try:
                 datetimes = self.datetime.split("/")

--- a/xpublish_edr/query.py
+++ b/xpublish_edr/query.py
@@ -59,32 +59,18 @@ class BaseEDRQuery(BaseModel):
     def select(self, ds: xr.Dataset, query_params: dict) -> xr.Dataset:
         """Select data from a dataset based on the query"""
         if self.z:
-            # Validate Z axis exists and is indexed
-            if "Z" not in ds.cf:
-                raise ValueError("Dataset has no vertical dimension for z queries")
-            z_coord = ds.cf["Z"]
-            if isinstance(z_coord, xr.DataArray) and z_coord.name not in ds.indexes:
+            try:
+                if self.method == "nearest":
+                    ds = ds.cf.sel(Z=[self.z], method=self.method)
+                else:
+                    ds = ds.cf.interp(Z=[self.z], method=self.method)
+            except KeyError as e:
                 raise ValueError(
-                    f"Vertical coordinate '{z_coord.name}' is not indexed and cannot "
-                    f"be queried. Available indexed dimensions: {list(ds.indexes.keys())}",
-                )
-            if self.method == "nearest":
-                ds = ds.cf.sel(Z=[self.z], method=self.method)
-            else:
-                ds = ds.cf.interp(Z=[self.z], method=self.method)
+                    f"Cannot select on Z axis: {e}. "
+                    f"Available indexed dimensions: {list(ds.indexes.keys())}",
+                ) from e
 
         if self.datetime:
-            # Validate T axis exists and is indexed
-            if "T" not in ds.cf:
-                raise ValueError(
-                    "Dataset has no temporal dimension for datetime queries",
-                )
-            t_coord = ds.cf["T"]
-            if isinstance(t_coord, xr.DataArray) and t_coord.name not in ds.indexes:
-                raise ValueError(
-                    f"Temporal coordinate '{t_coord.name}' is not indexed and cannot "
-                    f"be queried. Available indexed dimensions: {list(ds.indexes.keys())}",
-                )
             try:
                 datetimes = self.datetime.split("/")
                 if len(datetimes) == 1:
@@ -98,6 +84,11 @@ class BaseEDRQuery(BaseModel):
                     raise ValueError(
                         f"Invalid datetimes submitted - {datetimes}",
                     )
+            except KeyError as e:
+                raise ValueError(
+                    f"Cannot select on T axis: {e}. "
+                    f"Available indexed dimensions: {list(ds.indexes.keys())}",
+                ) from e
             except ValueError as e:
                 logger.error("Error with datetime", exc_info=True)
                 raise ValueError(f"Invalid datetime ({e})") from e

--- a/xpublish_edr/query.py
+++ b/xpublish_edr/query.py
@@ -59,12 +59,30 @@ class BaseEDRQuery(BaseModel):
     def select(self, ds: xr.Dataset, query_params: dict) -> xr.Dataset:
         """Select data from a dataset based on the query"""
         if self.z:
+            # Validate Z axis exists and is indexed
+            if "Z" not in ds.cf:
+                raise ValueError("Dataset has no vertical dimension for z queries")
+            z_coord = ds.cf["Z"]
+            if isinstance(z_coord, xr.DataArray) and z_coord.name not in ds.indexes:
+                raise ValueError(
+                    f"Vertical coordinate '{z_coord.name}' is not indexed and cannot "
+                    f"be queried. Available indexed dimensions: {list(ds.indexes.keys())}"
+                )
             if self.method == "nearest":
                 ds = ds.cf.sel(Z=[self.z], method=self.method)
             else:
                 ds = ds.cf.interp(Z=[self.z], method=self.method)
 
         if self.datetime:
+            # Validate T axis exists and is indexed
+            if "T" not in ds.cf:
+                raise ValueError("Dataset has no temporal dimension for datetime queries")
+            t_coord = ds.cf["T"]
+            if isinstance(t_coord, xr.DataArray) and t_coord.name not in ds.indexes:
+                raise ValueError(
+                    f"Temporal coordinate '{t_coord.name}' is not indexed and cannot "
+                    f"be queried. Available indexed dimensions: {list(ds.indexes.keys())}"
+                )
             try:
                 datetimes = self.datetime.split("/")
                 if len(datetimes) == 1:


### PR DESCRIPTION
In some datasets, the coordinates may not have indexes but will still be picked up by cf_xarray as the `T` axis, like in [this dataset](https://compute.earthmover.io/v1/services/edr/dynamical/noaa-gfs-forecast/main/) where `valid_time` does not have an index but it is a coordinate. 

We want to ensure coordinates for all extents specified in the metadata and at query time.