### PR TITLE
feature: support trajectory query

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ For `POLYGON` coordinates, points that are located within **OR** on the polygons
 
 Cube queries are not flattened like area queries, so the response is returned as sliced by xarray. This is particularly useful for subsetting regular grids.
 
+[8.2.5 Trajectory query](https://docs.ogc.org/is/19-086r6/19-086r6.html#_5181b3c7-ada4-40d9-bcf0-4c890a6087f1)
+
+| Query  | Compliant | Comments |
+| ------------- | ------------- | ------------- |
+| `coords`  | ✅ | `LINESTRING` and `MULTILINESTRING` (including Z/M/ZM where allowed); same CRS rules as other queries |
+| `z`  | ✅ | Must not duplicate a vertical (Z) dimension already present in WKT |
+| `datetime`  | ✅ | Must not duplicate M (measure) already present in WKT |
+| `parameter-name`  | ✅ | |
+| `crs`  | ✅ | Default `EPSG:4326` |
+| `f`  | ✅ | Same registry as position/area for trajectory (`cf_covjson`, `csv`, etc.); not `geotiff` |
+| `method`  | ➕ | Spatial indexing uses grid cells intersected by the path; `linear` does not interpolate along the path |
+
+**Sampling semantics:** the service rasterizes the path against the dataset’s regular 1D X/Y grid (via [rasterix](https://pypi.org/project/rasterix/)), takes **all grid cells touched** by the line, and returns them in **increasing distance along the line** measured at **cell center** points (ties keep a stable order). Collections need **at least two coordinates on each spatial axis** so a grid can be built; smaller grids are not advertised as trajectory-capable. Paths that miss the grid yield an empty spatial slice (HTTP 200 with empty coverage data).
+
 ## Get in touch
 
 Report bugs, suggest features or view the source code on [GitHub](https://github.com/gulfofmaine/xpublish-edr/issues).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,16 @@ netcdf4 = "xpublish_edr.formats.to_netcdf:to_netcdf"
 parquet = "xpublish_edr.formats.to_parquet:to_parquet"
 geotiff = "xpublish_edr.formats.to_geotiff:to_geotiff"
 
+[project.entry-points.xpublish_edr_trajectory_formats]
+cf_covjson = "xpublish_edr.formats.to_covjson:to_cf_covjson"
+csv = "xpublish_edr.formats.to_csv:to_csv"
+geojson = "xpublish_edr.formats.to_geojson:to_geojson"
+nc = "xpublish_edr.formats.to_netcdf:to_netcdf"
+netcdf = "xpublish_edr.formats.to_netcdf:to_netcdf"
+nc4 = "xpublish_edr.formats.to_netcdf:to_netcdf"
+netcdf4 = "xpublish_edr.formats.to_netcdf:to_netcdf"
+parquet = "xpublish_edr.formats.to_parquet:to_parquet"
+
 
 [tool.check-manifest]
 ignore = ["xpublish_edr/_version.py"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ pytest-cov
 pytest-flake8
 pytest-github-actions-annotate-failures
 pytest-xdist
+rasterix
 recommonmark
 ruff
 setuptools_scm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 geopandas
 pyarrow
+rasterix
 rioxarray
 scipy
 shapely

--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -1,9 +1,15 @@
 from io import BytesIO
+from urllib.parse import quote
 
 import cf_xarray  # noqa: F401
+import numpy as np
 import numpy.testing as npt
 import pandas as pd
+import pyproj
+import pyproj.exceptions
 import pytest
+import rioxarray
+import xarray as xr
 import xpublish
 from fastapi.testclient import TestClient
 
@@ -28,9 +34,26 @@ def cf_temp_dataset():
 
 
 @pytest.fixture(scope="session")
-def cf_xpublish(cf_air_dataset, cf_temp_dataset):
+def cf_single_cell_dataset(cf_air_dataset):
+    """Single lat/lon grid cell: metadata works but trajectory raster needs 2+ pixels/side."""
+    ds = cf_air_dataset.isel(lat=0, lon=0, drop=False)
+    ds.attrs = dict(cf_air_dataset.attrs)
+    ds.attrs["_xpublish_id"] = "single_cell"
+    return ds
+
+
+@pytest.fixture(scope="session")
+def cf_xpublish(
+    cf_air_dataset,
+    cf_temp_dataset,
+    cf_single_cell_dataset,
+):
     rest = xpublish.Rest(
-        {"air": cf_air_dataset, "temp": cf_temp_dataset},
+        {
+            "air": cf_air_dataset,
+            "temp": cf_temp_dataset,
+            "single_cell": cf_single_cell_dataset,
+        },
         plugins={"edr": CfEdrPlugin()},
     )
 
@@ -90,6 +113,23 @@ def test_cf_cube_formats(cf_client):
     assert "csv" in data, "csv is not reported as a valid format"
     assert "geojson" in data, "geojson is not reported as a valid format"
     assert "geotiff" in data, "geotiff is not reported as a valid format"
+
+
+def test_cf_trajectory_formats(cf_client):
+    response = cf_client.get("/edr/trajectory/formats")
+
+    assert response.status_code == 200, "Response did not return successfully"
+
+    data = response.json()
+
+    assert "cf_covjson" in data, "cf_covjson is not reported as a valid format"
+    assert "nc" in data, "nc is not reported as a valid format"
+    assert "csv" in data, "csv is not reported as a valid format"
+    assert "parquet" in data, "parquet is not reported as a valid format"
+    assert "geojson" in data, "geojson is not reported as a valid format"
+    assert (
+        "geotiff" not in data
+    ), "geotiff should not be advertised for trajectory queries"
 
 
 def test_cf_metadata_query(cf_client):
@@ -160,6 +200,17 @@ def test_cf_metadata_query(cf_client):
     assert (
         "position" in data["data_queries"] and "area" in data["data_queries"]
     ), "The data queries are incorrect"
+
+    assert (
+        "trajectory" in data["data_queries"]
+    ), "trajectory should be advertised for air"
+    traj = data["data_queries"]["trajectory"]
+    assert traj["link"]["href"] == "/edr/trajectory?coords={coords}"
+    assert traj["link"]["variables"]["query_type"] == "trajectory"
+    traj_formats = set(traj["link"]["variables"]["output_formats"])
+    assert "geotiff" not in traj_formats
+    for f in ("cf_covjson", "nc", "csv", "geojson", "parquet"):
+        assert f in traj_formats, f"{f} should be advertised for trajectory"
 
     assert (
         "temporal" and "spatial" in data["extent"]
@@ -857,10 +908,6 @@ def test_cf_cube_query_csv(cf_client, cf_air_dataset):
 
 @pytest.mark.parametrize("parameter", ["air", "air_float16"])
 def test_cf_cube_query_geotiff_latlng_grid(cf_client, cf_air_dataset, parameter):
-    import io
-
-    import rioxarray
-
     bbox = "200,40,210,50"
 
     # Test with multiple time steps
@@ -879,7 +926,7 @@ def test_cf_cube_query_geotiff_latlng_grid(cf_client, cf_air_dataset, parameter)
     ), "The file name should be data.tiff"
 
     # Read the GeoTIFF back in from the response content
-    da = rioxarray.open_rasterio(io.BytesIO(response.content))
+    da = rioxarray.open_rasterio(BytesIO(response.content))
     assert da.band.shape == (
         4,
     ), "GeoTIFF should have 4 time steps represented as bands"
@@ -890,9 +937,6 @@ def test_cf_cube_query_geotiff_latlng_grid(cf_client, cf_air_dataset, parameter)
         5,
         5,
     ), "GeoTIFF should have 4 time steps, 5 x coordinates, and 5 y coordinates"
-
-    with open("test_cf_cube_query_geotiff_latlng_grid.tiff", "wb") as f:
-        f.write(response.content)
 
     # Test with a single time step
     response = cf_client.get(
@@ -910,7 +954,7 @@ def test_cf_cube_query_geotiff_latlng_grid(cf_client, cf_air_dataset, parameter)
     ), "The file name should be data.tiff"
 
     # Read the GeoTIFF back in from the response content
-    da = rioxarray.open_rasterio(io.BytesIO(response.content))
+    da = rioxarray.open_rasterio(BytesIO(response.content))
     assert da.band.shape == (1,), "GeoTIFF should have 1 time step represented as bands"
     assert da.x.shape == (5,), "GeoTIFF should have 5 x coordinates"
     assert da.y.shape == (5,), "GeoTIFF should have 5 y coordinates"
@@ -922,9 +966,6 @@ def test_cf_cube_query_geotiff_latlng_grid(cf_client, cf_air_dataset, parameter)
 
 
 def test_cf_generic_extents_band_and_step():
-    import numpy as np
-    import xarray as xr
-
     # Build coords: lat/lon for CF spatial axes, plus band (int) and step (timedelta)
     lat = xr.DataArray(
         [10.0, 11.0],
@@ -1038,3 +1079,133 @@ def test_cf_generic_extents_band_and_step():
     # parameter_names includes extents
     assert set(meta["parameter_names"]["var"]["extent"]) == {"spatial", "band", "step"}
     assert set(meta["parameter_names"]["big"]["extent"].keys()) == {"spatial", "member"}
+
+
+def test_cf_trajectory_query_success(cf_client):
+    coords = "LINESTRING(204 44, 208 46)"
+    response = cf_client.get(f"/datasets/air/edr/trajectory?coords={coords}")
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+    data = response.json()
+    assert "ranges" in data and "air" in data["ranges"]
+    assert data["ranges"]["air"]["axisNames"] == ["t", "pts"]
+
+
+def test_cf_trajectory_query_non_default_request_crs(cf_client):
+    """Request `coords` in Web Mercator (`crs=EPSG:3857`) against a geographic grid."""
+    tf = pyproj.Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)
+    x1, y1 = tf.transform(204.0, 44.0)
+    x2, y2 = tf.transform(208.0, 46.0)
+    wkt = f"LINESTRING({x1} {y1}, {x2} {y2})"
+    response = cf_client.get(
+        f"/datasets/air/edr/trajectory?coords={quote(wkt)}&crs=EPSG:3857",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "air" in data["ranges"]
+
+
+def test_cf_trajectory_query_parameter_name(cf_client):
+    coords = "LINESTRING(204 44, 205 45)"
+    response = cf_client.get(
+        f"/datasets/air/edr/trajectory?coords={coords}&parameter-name=air",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "air" in data["ranges"]
+    assert "air_float16" not in data["ranges"]
+
+
+def test_cf_trajectory_query_incapable(cf_client):
+    response = cf_client.get(
+        "/datasets/single_cell/edr/trajectory?coords=LINESTRING(200 15, 322 75)",
+    )
+    assert response.status_code == 404
+    assert "not supported" in response.json()["detail"].lower()
+
+
+@pytest.mark.parametrize("ds_id", ["air", "temp"])
+def test_cf_trajectory_metadata_on_capable_collections(cf_client, ds_id):
+    response = cf_client.get(f"/datasets/{ds_id}/edr/")
+    assert response.status_code == 200
+    data = response.json()
+    assert "trajectory" in data["data_queries"]
+    traj = data["data_queries"]["trajectory"]
+    assert traj["link"]["href"] == "/edr/trajectory?coords={coords}"
+    assert traj["link"]["variables"]["query_type"] == "trajectory"
+
+
+def test_cf_trajectory_metadata_crs_parity_with_position_air(cf_client):
+    """Trajectory discovery should advertise the same CRS list as position for a collection."""
+    response = cf_client.get("/datasets/air/edr/")
+    assert response.status_code == 200
+    data = response.json()
+    pos_crs = data["data_queries"]["position"]["link"]["variables"]["crs_details"]
+    traj_crs = data["data_queries"]["trajectory"]["link"]["variables"]["crs_details"]
+    assert pos_crs == traj_crs
+
+
+def test_cf_trajectory_metadata_absent_on_incapable_collection(cf_client):
+    response = cf_client.get("/datasets/single_cell/edr/")
+    assert response.status_code == 200
+    data = response.json()
+    assert "trajectory" not in data.get("data_queries", {})
+
+
+@pytest.mark.parametrize(
+    ("path", "expect_status"),
+    [
+        ("/datasets/air/edr/trajectory", 422),
+        ("/datasets/air/edr/trajectory?coords=POINT(204 44)", 422),
+        (
+            "/datasets/air/edr/trajectory?coords=LINESTRING(204 44, 205 45)&crs=not-a-crs",
+            422,
+        ),
+    ],
+)
+def test_cf_trajectory_client_errors(cf_client, path, expect_status):
+    response = cf_client.get(path)
+    assert response.status_code == expect_status
+
+
+def test_cf_trajectory_projection_failure_returns_422(cf_client, monkeypatch):
+    """If coordinate projection fails (e.g. pyproj), respond with client error, not 500."""
+
+    def _raise_proj_error(*_args, **_kwargs):
+        raise pyproj.exceptions.ProjError("simulated coordinate transform failure")
+
+    monkeypatch.setattr(
+        "xpublish_edr.geometry.common.transformer_from_crs",
+        _raise_proj_error,
+    )
+    response = cf_client.get(
+        "/datasets/air/edr/trajectory?coords=LINESTRING(204%2044,205%2045)",
+    )
+    assert response.status_code == 422
+    assert "crs" in response.json()["detail"].lower()
+
+
+def test_cf_trajectory_unsupported_format(cf_client):
+    response = cf_client.get(
+        "/datasets/air/edr/trajectory?coords=LINESTRING(204 44, 205 45)&f=geotiff",
+    )
+    assert response.status_code == 422
+
+
+def test_cf_trajectory_outside_extent_empty(cf_client):
+    """Path outside the grid: 200 with empty spatial slice (no intersected cells)."""
+    response = cf_client.get(
+        "/datasets/air/edr/trajectory?coords=LINESTRING(-170 10, -169 11)",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ranges"]["air"]["shape"] == [4, 0, 0]
+    assert data["ranges"]["air"]["values"] == []
+
+
+def test_cf_trajectory_multilinestring(cf_client):
+    wkt = "MULTILINESTRING ((204 44, 205 45), (207 46, 208 47))"
+    response = cf_client.get(f"/datasets/air/edr/trajectory?coords={wkt}")
+    assert response.status_code == 200
+    data = response.json()
+    assert "air" in data["ranges"]

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -4,6 +4,7 @@ import numpy.testing as npt
 import pandas as pd
 import pyproj
 import pytest
+import rioxarray  # noqa: F401  # registers xarray.rio accessor
 import xarray as xr
 import xarray.testing as xrt
 from shapely import MultiPoint, Point, from_wkt
@@ -12,7 +13,12 @@ from xpublish_edr.geometry.area import select_by_area
 from xpublish_edr.geometry.bbox import select_by_bbox
 from xpublish_edr.geometry.common import project_dataset
 from xpublish_edr.geometry.position import select_by_position
-from xpublish_edr.query import EDRAreaQuery, EDRCubeQuery, EDRPositionQuery
+from xpublish_edr.geometry.trajectory import select_by_trajectory
+from xpublish_edr.query import (
+    EDRAreaQuery,
+    EDRCubeQuery,
+    EDRPositionQuery,
+)
 
 
 @pytest.fixture(scope="function")
@@ -208,7 +214,7 @@ def test_select_query_error(regular_xy_dataset):
         parameters="air",
     )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError, match="Invalid datetime"):
         query.select(regular_xy_dataset, {})
 
     query = EDRPositionQuery(
@@ -606,3 +612,15 @@ def test_z_query_error_non_indexed(dataset_with_non_indexed_axes):
     )
     with pytest.raises(ValueError, match="Cannot select on Z axis via cf_xarray"):
         query.select(dataset_with_non_indexed_axes, {})
+
+
+def test_select_trajectory_order_along_line(regular_xy_dataset):
+    """Along-path order matches increasing distance along the WKT line (stable sort)."""
+    line = from_wkt("LINESTRING(200 40, 210 50)")
+    ds = select_by_trajectory(regular_xy_dataset, line)
+    xs = ds.cf["X"].values
+    ys = ds.cf["Y"].values
+    dists = [
+        line.project(Point(float(x), float(y))) for x, y in zip(xs, ys, strict=True)
+    ]
+    assert dists == sorted(dists)

--- a/xpublish_edr/format.py
+++ b/xpublish_edr/format.py
@@ -45,3 +45,17 @@ def cube_formats():
         formats[entry_point.name] = entry_point.load()
 
     return formats
+
+
+def trajectory_formats():
+    """
+    Return response format functions from registered
+    `xpublish_edr_trajectory_formats` entry_points
+    """
+    formats = {}
+
+    entry_points = importlib.metadata.entry_points()
+    for entry_point in entry_points.select(group="xpublish_edr_trajectory_formats"):
+        formats[entry_point.name] = entry_point.load()
+
+    return formats

--- a/xpublish_edr/geometry/common.py
+++ b/xpublish_edr/geometry/common.py
@@ -72,6 +72,7 @@ def get_default_grid_mapping(ds: xr.Dataset) -> pyproj.CRS:
 
 
 def dataset_crs(ds: xr.Dataset) -> pyproj.CRS:
+    """Return the dataset CRS from CF ``grid_mapping``, or a sensible default."""
     grid_mapping_names = ds.cf.grid_mapping_names
     if len(grid_mapping_names) == 0:
         return get_default_grid_mapping(ds)

--- a/xpublish_edr/geometry/trajectory.py
+++ b/xpublish_edr/geometry/trajectory.py
@@ -1,0 +1,241 @@
+"""
+Handle selection and formatting for trajectory queries
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import geopandas as gpd
+import numpy as np
+import shapely
+import xarray as xr
+from rasterix.rasterize import rasterize
+
+from xpublish_edr.geometry.common import (
+    VECTORIZED_DIM,
+    dataset_crs,
+    is_regular_xy_coords,
+)
+from xpublish_edr.logger import logger
+
+
+def select_by_trajectory(
+    ds: xr.Dataset,
+    line: shapely.LineString | shapely.MultiLineString,
+    method: Literal["nearest", "linear"] = "nearest",
+) -> xr.Dataset:
+    """
+    Return a dataset with grid cells intersected by the line, ordered by distance
+    along the line through cell center points (stable tie-break by index order).
+    """
+    if not is_regular_xy_coords(ds):
+        # TODO: Handle 2D coordinates
+        raise NotImplementedError("Only  2D coordinates are supported")
+
+    if line.is_empty:
+        return _empty_trajectory_dataset(ds)
+
+    ds_sub = _subset_to_line_bbox(ds, line)
+    if ds_sub is None:
+        return _empty_trajectory_dataset(ds)
+
+    x_dim = ds.cf["X"].dims[0]
+    y_dim = ds.cf["Y"].dims[0]
+
+    data_crs = dataset_crs(ds_sub)
+    gdf = gpd.GeoDataFrame(geometry=[line], crs=data_crs)
+
+    try:
+        y_nz, x_nz = _intersected_cell_indices(ds_sub, gdf, x_dim, y_dim)
+    except Exception as e:
+        logger.error("Rasterize failed for trajectory query: %s", e, exc_info=True)
+        raise KeyError(
+            "Trajectory rasterization failed; check CRS, grid metadata, and geometry.",
+        ) from e
+
+    return _sort_cells_along_line(ds_sub, y_nz, x_nz, line, x_dim, y_dim, method)
+
+
+def _subset_to_line_bbox(
+    ds: xr.Dataset,
+    line: shapely.LineString | shapely.MultiLineString,
+) -> xr.Dataset | None:
+    """
+    Return a spatial subset of ds covering the line bounding box, or None when empty.
+
+    Falls back to the full dataset when the subset is too small for rasterix to infer
+    pixel size (fewer than two samples on either axis).
+    """
+    x_dim = ds.cf["X"].dims[0]
+    y_dim = ds.cf["Y"].dims[0]
+
+    minx, miny, maxx, maxy = line.bounds
+    indexes = ds.cf.indexes
+    x_sel = (
+        slice(minx, maxx) if indexes["X"].is_monotonic_increasing else slice(maxx, minx)
+    )
+    y_sel = (
+        slice(miny, maxy) if indexes["Y"].is_monotonic_increasing else slice(maxy, miny)
+    )
+
+    try:
+        ds_sub = ds.cf.sel(X=x_sel, Y=y_sel)
+    except Exception as e:
+        logger.debug("Trajectory bbox subset failed: %s", e)
+        return None
+
+    if ds_sub.sizes.get(x_dim, 0) == 0 or ds_sub.sizes.get(y_dim, 0) == 0:
+        return None
+
+    # rasterix needs at least two samples per axis to infer pixel size
+    if ds_sub.sizes.get(x_dim, 0) < 2 or ds_sub.sizes.get(y_dim, 0) < 2:
+        return ds
+
+    return ds_sub
+
+
+def _sort_cells_along_line(
+    ds_sub: xr.Dataset,
+    y_nz: np.ndarray,
+    x_nz: np.ndarray,
+    line: shapely.LineString | shapely.MultiLineString,
+    x_dim: str,
+    y_dim: str,
+    method: Literal["nearest", "linear"],
+) -> xr.Dataset:
+    """
+    Select and order the rasterized cells by their projected distance along the line.
+    """
+    if y_nz.size == 0:
+        return _empty_trajectory_dataset(ds_sub)
+
+    x_coords = np.asarray(ds_sub.cf["X"].values)[x_nz]
+    y_coords = np.asarray(ds_sub.cf["Y"].values)[y_nz]
+    dists = np.array(
+        [
+            line.project(shapely.Point(float(x), float(y)))
+            for x, y in zip(x_coords, y_coords)
+        ],
+    )
+    order = np.argsort(dists, kind="stable")
+
+    x_var = xr.Variable(dims=VECTORIZED_DIM, data=x_nz[order])
+    y_var = xr.Variable(dims=VECTORIZED_DIM, data=y_nz[order])
+
+    if method == "linear":
+        logger.warning(
+            "Trajectory selection does not interpolate along the path; "
+            "'linear' is treated like 'nearest' for spatial indexing.",
+        )
+    return ds_sub.cf.isel(X=x_var, Y=y_var)
+
+
+def _intersected_cell_indices(
+    ds_sub: xr.Dataset,
+    gdf: gpd.GeoDataFrame,
+    x_dim: str,
+    y_dim: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Return `(y_idx, x_idx)` for cells intersected by the input line.
+
+    Strategy:
+    1. Prefer exactextract coverage because it provides a sparse mask and avoids
+       building dense intermediates.
+    2. Fall back to rusterize for a fast rasterization path without GDAL.
+    3. Fall back to rasterio with all_touched for parity with legacy behavior.
+    """
+    try:
+        cover = _exactextract_coverage(ds_sub, gdf, xdim=x_dim, ydim=y_dim, clip=False)
+        if "geometry" in cover.dims:
+            cover = cover.isel(geometry=0, drop=True)
+        return _nonzero_indices(cover, x_dim, y_dim)
+    except Exception as e:
+        logger.debug("exactextract coverage failed for trajectory query: %s", e)
+
+    try:
+        burned = rasterize(
+            ds_sub,
+            gdf,
+            xdim=x_dim,
+            ydim=y_dim,
+            clip=False,
+            merge_alg="replace",
+            engine="rusterize",
+        )
+        return _burned_nonfill_indices(burned)
+    except Exception as e:
+        logger.debug("rusterize failed for trajectory query: %s", e)
+
+    burned = rasterize(
+        ds_sub,
+        gdf,
+        xdim=x_dim,
+        ydim=y_dim,
+        clip=False,
+        all_touched=True,
+        merge_alg="replace",
+        engine="rasterio",
+    )
+    return _burned_nonfill_indices(burned)
+
+
+def _nonzero_indices(
+    data: xr.DataArray,
+    x_dim: str,
+    y_dim: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Return non-zero cell indices for a 2D mask data array.
+
+    Uses sparse-array coordinate indices directly when available to avoid densifying.
+    """
+    y_axis = data.get_axis_num(y_dim)
+    x_axis = data.get_axis_num(x_dim)
+    mask_data = data.data
+    if hasattr(mask_data, "coords"):
+        return (
+            np.asarray(mask_data.coords[y_axis], dtype=np.intp),
+            np.asarray(mask_data.coords[x_axis], dtype=np.intp),
+        )
+
+    dense = np.asarray(data.values)
+    return np.nonzero(dense > 0)
+
+
+def _burned_nonfill_indices(burned: xr.DataArray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Return indices for rasterized pixels that are not equal to fill value.
+    """
+    arr = np.asarray(burned.values)
+    fill = int(arr.max()) if arr.size else 0
+    return np.nonzero(arr != fill)
+
+
+def _exactextract_coverage(
+    ds_sub: xr.Dataset,
+    gdf: gpd.GeoDataFrame,
+    xdim: str,
+    ydim: str,
+    clip: bool,
+) -> xr.DataArray:
+    """
+    Lazily import exactextract coverage support.
+
+    rasterix' exactextract path depends on optional extras (`sparse`, exactextract).
+    Delaying the import keeps trajectory queries importable even when extras are
+    unavailable; runtime fallback handles the missing dependency.
+    """
+    from rasterix.rasterize.exact import coverage
+
+    return coverage(ds_sub, gdf, xdim=xdim, ydim=ydim, clip=clip)
+
+
+def _empty_trajectory_dataset(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Return an empty spatial subset (no intersected cells), encodable as CoverageJSON.
+    """
+    x_dim = ds.cf["X"].dims[0]
+    y_dim = ds.cf["Y"].dims[0]
+    return ds.isel({x_dim: slice(0, 0), y_dim: slice(0, 0)})

--- a/xpublish_edr/metadata.py
+++ b/xpublish_edr/metadata.py
@@ -1,3 +1,5 @@
+"""OGC API–EDR collection metadata models and helpers."""
+
 from typing import Literal, Optional, cast
 
 import numpy as np
@@ -9,6 +11,7 @@ from pydantic import BaseModel, Field, model_serializer
 from xpublish_edr.geometry.common import (
     DEFAULT_CRS,
     dataset_crs,
+    is_regular_xy_coords,
     spatial_bounds,
 )
 from xpublish_edr.logger import logger
@@ -127,6 +130,7 @@ class Extent(BaseModel):
 
     @model_serializer(mode="wrap")
     def _flatten_other(self, handler):
+        """Merge ``other`` extent keys into the serialized top-level dict."""
         data = handler(self)
         other = data.pop("other", None)
         if isinstance(other, dict):
@@ -342,6 +346,7 @@ def vertical_extent(ds: xr.Dataset) -> Optional[VerticalExtent]:
 
 
 def _timedelta_to_iso(val: object) -> str:
+    """Format a timedelta-like value as an ISO-8601 duration string."""
     td = pd.Timedelta(val)
     # Prefer pandas ISO-8601 when available
     if hasattr(td, "isoformat"):
@@ -353,6 +358,7 @@ def _timedelta_to_iso(val: object) -> str:
 
 
 def _values_to_python_list(values: np.ndarray) -> list[int | float | str]:
+    """Convert axis coordinate values to JSON-friendly Python scalars or strings."""
     arr = np.asarray(values)
     # datetime-like
     if np.issubdtype(arr.dtype, np.datetime64):
@@ -578,11 +584,65 @@ def cube_query_description(
     )
 
 
+def trajectory_query_description(
+    output_formats: list[str],
+    crs_details: list[CRSDetails],
+) -> EDRQueryMetadata:
+    """
+    Return CF version of EDR Trajectory Query metadata
+    """
+    return EDRQueryMetadata(
+        link=Link(
+            href="/edr/trajectory?coords={coords}",
+            hreflang="en",
+            rel="data",
+            templated=True,
+            variables=VariablesMetadata(
+                title="Trajectory query",
+                description="Returns data along a path from WKT `LINESTRING` or `MULTILINESTRING`",
+                query_type="trajectory",
+                coords={
+                    "type": "string",
+                    "description": "WKT `LINESTRING` or `MULTILINESTRING` coordinates",
+                    "required": True,
+                },
+                output_formats=output_formats,
+                default_output_format="cf_covjson",
+                crs_details=crs_details,
+            ),
+        ),
+    )
+
+
+def is_trajectory_capable_dataset(ds: xr.Dataset) -> bool:
+    """
+    Return True if the dataset can be served by the trajectory implementation.
+
+    Trajectory selection requires a regular one-dimensional CF X axis and Y axis
+    (the same constraint as position and area queries on rectilinear grids), and
+    at least two coordinate values on each spatial axis so a pixel grid can be
+    constructed for rasterization.
+    """
+    try:
+        if not is_regular_xy_coords(ds):
+            return False
+        x_dim = ds.cf["X"].dims[0]
+        y_dim = ds.cf["Y"].dims[0]
+        return ds.sizes.get(x_dim, 0) >= 2 and ds.sizes.get(y_dim, 0) >= 2
+    except Exception:
+        logger.debug(
+            "Trajectory capability check failed for dataset",
+            exc_info=True,
+        )
+        return False
+
+
 def collection_metadata(
     ds: xr.Dataset,
     position_output_formats: list[str],
     area_output_formats: list[str],
     cube_output_formats: list[str],
+    trajectory_output_formats: list[str] | None = None,
 ) -> Collection:
     """
     Returns the collection metadata for the dataset
@@ -618,6 +678,17 @@ def collection_metadata(
         for f in position_output_formats
         if f in area_output_formats and f in cube_output_formats
     ]
+    if trajectory_output_formats is not None:
+        common_output_formats = [
+            f for f in common_output_formats if f in trajectory_output_formats
+        ]
+
+    trajectory_query_meta = None
+    if trajectory_output_formats is not None and is_trajectory_capable_dataset(ds):
+        trajectory_query_meta = trajectory_query_description(
+            trajectory_output_formats,
+            supported_crs,
+        )
 
     return Collection(
         links=[],
@@ -630,6 +701,7 @@ def collection_metadata(
             position=position_query_description(position_output_formats, supported_crs),
             area=area_query_description(area_output_formats, supported_crs),
             cube=cube_query_description(cube_output_formats, supported_crs),
+            trajectory=trajectory_query_meta,
         ),
         crs=[crs.to_string()],
         output_formats=common_output_formats,

--- a/xpublish_edr/plugin.py
+++ b/xpublish_edr/plugin.py
@@ -9,15 +9,26 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from shapely.errors import GEOSException
 from xpublish import Dependencies, Plugin, hookimpl
 
-from xpublish_edr.format import area_formats, cube_formats, position_formats
+from xpublish_edr.format import (
+    area_formats,
+    cube_formats,
+    position_formats,
+    trajectory_formats,
+)
 from xpublish_edr.formats.to_covjson import to_cf_covjson
 from xpublish_edr.geometry.area import select_by_area
 from xpublish_edr.geometry.bbox import select_by_bbox
 from xpublish_edr.geometry.common import project_dataset
 from xpublish_edr.geometry.position import select_by_position
+from xpublish_edr.geometry.trajectory import select_by_trajectory
 from xpublish_edr.logger import logger
-from xpublish_edr.metadata import collection_metadata
-from xpublish_edr.query import EDRAreaQuery, EDRCubeQuery, EDRPositionQuery
+from xpublish_edr.metadata import collection_metadata, is_trajectory_capable_dataset
+from xpublish_edr.query import (
+    EDRAreaQuery,
+    EDRCubeQuery,
+    EDRPositionQuery,
+    EDRTrajectoryQuery,
+)
 
 
 class CfEdrPlugin(Plugin):
@@ -70,6 +81,19 @@ class CfEdrPlugin(Plugin):
             formats = {key: value.__doc__ for key, value in cube_formats().items()}
             return formats
 
+        @router.get(
+            "/trajectory/formats",
+            summary="Trajectory query response formats",
+        )
+        def get_trajectory_formats():
+            """
+            Returns the various supported formats for trajectory queries
+            """
+            formats = {
+                key: value.__doc__ for key, value in trajectory_formats().items()
+            }
+            return formats
+
         return router
 
     @hookimpl
@@ -89,11 +113,13 @@ class CfEdrPlugin(Plugin):
             position_output_formats = list(position_formats().keys())
             area_output_formats = list(area_formats().keys())
             cube_output_formats = list(cube_formats().keys())
+            trajectory_output_formats = list(trajectory_formats().keys())
             return collection_metadata(
                 dataset,
                 position_output_formats,
                 area_output_formats,
                 cube_output_formats,
+                trajectory_output_formats=trajectory_output_formats,
             ).dict(
                 exclude_none=True,
             )
@@ -306,6 +332,109 @@ class CfEdrPlugin(Plugin):
                         404,
                         f"{query.format} is not a valid format for EDR cube queries. "
                         "Get `./cube/formats` for valid formats",
+                    )
+
+                return format_fn(ds)
+
+            return to_cf_covjson(ds)
+
+        @router.get("/trajectory", summary="Trajectory query")
+        def get_trajectory(
+            request: Request,
+            query: Annotated[EDRTrajectoryQuery, Query()],
+            dataset: xr.Dataset = Depends(deps.dataset),
+        ):
+            """
+            Returns data along a path from WKT `LINESTRING` or `MULTILINESTRING` coordinates
+
+            Extra selecting/slicing parameters can be provided as extra query parameters
+            """
+            if not is_trajectory_capable_dataset(dataset):
+                raise HTTPException(
+                    status_code=404,
+                    detail="Trajectory queries are not supported for this collection",
+                )
+
+            try:
+                ds = query.select(dataset, dict(request.query_params))
+            except ValueError as e:
+                logger.error(
+                    f"Error selecting from query while selecting by trajectory: {e}",
+                )
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Error selecting from query: {e.args[0]}",
+                )
+
+            logger.debug(f"Dataset filtered by query params {ds}")
+
+            try:
+                projected = query.project_geometry(ds)
+            except Exception as e:
+                logger.error(
+                    f"Error projecting trajectory geometry: {e}",
+                    exc_info=True,
+                )
+                raise HTTPException(
+                    status_code=422,
+                    detail="Could not project trajectory geometry; check 'crs' and 'coords'",
+                ) from e
+
+            try:
+                ds = select_by_trajectory(ds, projected, query.method)
+            except GEOSException as e:
+                logger.error(
+                    f"Error parsing coordinates to geometry while selecting by trajectory: {e}",
+                )
+                raise HTTPException(
+                    status_code=422,
+                    detail="Could not parse coordinates to geometry, "
+                    + "check the format of the 'coords' query parameter",
+                )
+            except NotImplementedError as e:
+                logger.error(f"Trajectory query not implemented for this grid: {e}")
+                raise HTTPException(
+                    status_code=404,
+                    detail=str(e),
+                )
+            except KeyError as e:
+                logger.error(f"Error selecting by trajectory: {e}")
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"Error selecting by trajectory: {e}. "
+                        "Ensure the dataset has valid CF metadata and 1D X/Y coordinates."
+                    ),
+                )
+
+            logger.debug(
+                f"Dataset filtered by trajectory ({query.geometry}): {ds}",
+            )
+
+            try:
+                ds = project_dataset(ds, query.crs)
+            except Exception as e:
+                logger.error(
+                    f"Error projecting dataset while selecting by trajectory: {e}",
+                )
+                raise HTTPException(
+                    status_code=404,
+                    detail="Error projecting dataset",
+                )
+
+            logger.debug(f"Dataset projected to {query.crs}: {ds}")
+
+            if query.format:
+                try:
+                    format_fn = trajectory_formats()[query.format]
+                except KeyError as e:
+                    logger.error(
+                        f"Error getting format function while selecting by trajectory: {e}",
+                    )
+                    raise HTTPException(
+                        404,
+                        f"{query.format} is not a valid format for EDR trajectory queries. "
+                        "Get `./trajectory/formats` for valid formats",
                     )
 
                 return format_fn(ds)

--- a/xpublish_edr/query.py
+++ b/xpublish_edr/query.py
@@ -2,14 +2,20 @@
 OGC EDR Query param parsing
 """
 
-from typing import Literal, Optional
+from typing import Literal, Optional, Self
 
 import numpy as np
+import pyproj
 import xarray as xr
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from shapely import Geometry, wkt
 
-from xpublish_edr.format import area_formats, cube_formats, position_formats
+from xpublish_edr.format import (
+    area_formats,
+    cube_formats,
+    position_formats,
+    trajectory_formats,
+)
 from xpublish_edr.geometry.common import project_bbox, project_geometry
 from xpublish_edr.logger import logger
 
@@ -64,7 +70,7 @@ class BaseEDRQuery(BaseModel):
                     ds = ds.cf.sel(Z=[self.z], method=self.method)
                 else:
                     ds = ds.cf.interp(Z=[self.z], method=self.method)
-            except KeyError as e:
+            except (KeyError, TypeError) as e:
                 raise ValueError(
                     f"Cannot select on Z axis via cf_xarray: {e}. "
                     f"The Z coordinate may not be indexed. "
@@ -85,6 +91,19 @@ class BaseEDRQuery(BaseModel):
                     raise ValueError(
                         f"Invalid datetimes submitted - {datetimes}",
                     )
+            except TypeError as e:
+                err_msg = str(e)
+                if (
+                    "Timestamp" in err_msg
+                    and "not supported between instances" in err_msg
+                ):
+                    logger.error("Error with datetime", exc_info=True)
+                    raise ValueError(f"Invalid datetime ({e})") from e
+                raise ValueError(
+                    f"Cannot select on T axis via cf_xarray: {e}. "
+                    f"The T coordinate may not be indexed. "
+                    f"Indexed dimensions available for direct selection: {list(ds.indexes.keys())}",
+                ) from e
             except KeyError as e:
                 raise ValueError(
                     f"Cannot select on T axis via cf_xarray: {e}. "
@@ -92,6 +111,15 @@ class BaseEDRQuery(BaseModel):
                     f"Indexed dimensions available for direct selection: {list(ds.indexes.keys())}",
                 ) from e
             except ValueError as e:
+                err_msg = str(e)
+                if "Invalid datetimes submitted" in err_msg:
+                    raise
+                if "PandasIndex" in err_msg or "set_xindex" in err_msg:
+                    raise ValueError(
+                        f"Cannot select on T axis via cf_xarray: {e}. "
+                        f"The T coordinate may not be indexed. "
+                        f"Indexed dimensions available for direct selection: {list(ds.indexes.keys())}",
+                    ) from e
                 logger.error("Error with datetime", exc_info=True)
                 raise ValueError(f"Invalid datetime ({e})") from e
 
@@ -240,6 +268,82 @@ class EDRCubeQuery(BaseEDRQuery):
     def project_bbox(self, ds: xr.Dataset) -> tuple[float, float, float, float]:
         """Project the bbox to the dataset's CRS"""
         return project_bbox(ds, self.crs, self.bbox)
+
+
+class EDRTrajectoryQuery(BaseEDRQuery):
+    """
+    Capture query parameters for EDR trajectory queries
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    format: Optional[str] = Field(
+        None,
+        title="Response format",
+        description="Trajectory response format key. "
+        f"Valid keys: {', '.join(sorted(trajectory_formats().keys()))}.",
+        validation_alias="f",
+    )
+    coords: str = Field(
+        ...,
+        title="Line(s) in WKT format",
+        description="Well Known Text coordinates for LINESTRING or MULTILINESTRING",
+    )
+
+    @field_validator("format", mode="before")
+    @classmethod
+    def validate_format(cls, v):
+        """Validate the format is a registered trajectory format."""
+        if v is None:
+            return v
+        if v not in trajectory_formats().keys():
+            raise ValueError(f"Invalid format: {v}")
+        return v
+
+    @field_validator("crs", mode="after")
+    @classmethod
+    def validate_crs(cls, v: str) -> str:
+        """Reject CRS strings that pyproj cannot interpret."""
+        try:
+            pyproj.CRS.from_user_input(v)
+        except Exception as e:
+            raise ValueError(f"Unsupported CRS: {v!r}") from e
+        return v
+
+    @field_validator("coords", mode="after")
+    @classmethod
+    def validate_line_geometry(cls, v: str) -> str:
+        """Ensure WKT is a supported line geometry for trajectory queries."""
+        geom = validate_wkt(v)
+        if geom.geom_type not in ("LineString", "MultiLineString"):
+            raise ValueError(
+                f"Trajectory coords must be LINESTRING or MULTILINESTRING, got {geom.geom_type}",
+            )
+        return v
+
+    @model_validator(mode="after")
+    def validate_fr004_vertical_temporal(self) -> Self:
+        """Enforce OGC EDR rules for Z/M vs query parameters (FR-004)."""
+        geom = wkt.loads(self.coords)
+        if geom.has_z and self.z is not None:
+            raise ValueError(
+                "Cannot use query parameter 'z' when coordinates include a Z dimension",
+            )
+        if getattr(geom, "has_m", False) and self.datetime is not None:
+            raise ValueError(
+                "Cannot use query parameter 'datetime' when coordinates include an M "
+                "(measure) dimension",
+            )
+        return self
+
+    @property
+    def geometry(self) -> Geometry:
+        """Shapely line geometry from WKT query params."""
+        return wkt.loads(self.coords)
+
+    def project_geometry(self, ds: xr.Dataset) -> Geometry:
+        """Project the geometry to the dataset's CRS"""
+        return project_geometry(ds, self.crs, self.geometry)
 
 
 edr_query_params = {


### PR DESCRIPTION
## Motivation

Address [issue #102](https://github.com/xpublish-community/xpublish-edr/issues/102): add robust **OGC API–EDR trajectory** support ([19-086r6 §8.2.5](https://docs.ogc.org/is/19-086r6/19-086r6.html#_5181b3c7-ada4-40d9-bcf0-4c890a6087f1)) so clients can request values along WKT `LINESTRING` / `MULTILINESTRING` paths, with discovery/CRS behavior aligned to existing EDR query types.

## Routes and request contract

- **Routes**: `GET .../edr/trajectory` and `GET .../edr/trajectory/formats`
- **Query params**: required `coords`; optional `z`, `datetime`, `parameter-name`, `crs` (default `EPSG:4326`), `f`, `method`
- **Validation**: invalid WKT, non-line geometry, invalid CRS, and Z/M conflicts with `z`/`datetime` return **422** (Pydantic/FastAPI), consistent with other endpoints

## Implementation details

`select_by_trajectory` prioritizes efficient raster intersection and avoids unnecessary dense materialization where possible:

1. **Try `exactextract` coverage first** (sparse coverage path when available)
2. **Fallback to `rusterize`**
3. **Fallback to `rasterio` + `all_touched=True`** for compatibility parity
