### PR TITLE
fix(covjson): guard np.isnan calls against non-float dtypes

### DIFF
--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -349,6 +349,48 @@ def test_cf_position_covjson_integer_coord(tmp_path):
     assert "annualFireProbability" in data_json["ranges"]
 
 
+def test_to_csv_drops_index_only_dims_and_crs_vars():
+    """to_csv should drop bare 0-based dimension-index columns and scalar CRS
+    metadata variables that arise when project_dataset reprojects a dataset."""
+    import io
+
+    import numpy as np
+    import pandas as pd
+    import xarray as xr
+
+    from xpublish_edr.formats.to_csv import to_csv
+
+    # Simulate the post-reprojection dataset structure:
+    # lat/lon dims have NO coordinate values (dropped by project_dataset);
+    # latitude/longitude are 2D non-dimension coords with actual projected values;
+    # spatial_ref is a scalar CRS variable written by rioxarray.write_crs().
+    year = np.array([1995, 2020], dtype="int32")
+    data = np.ones((2, 1, 1))
+
+    ds = xr.Dataset(
+        {"annualFireProbability": (["year", "lat", "lon"], data)},
+        coords={
+            "year": ("year", year),
+            "longitude": (["lat", "lon"], np.array([[-95.8]])),
+            "latitude": (["lat", "lon"], np.array([[35.3]])),
+        },
+    )
+    ds["spatial_ref"] = xr.Variable(
+        [],
+        0,
+        attrs={"grid_mapping_name": "latitude_longitude", "crs_wkt": "GEOGCS[...]"},
+    )
+
+    response = to_csv(ds)
+    df = pd.read_csv(io.StringIO(response.body.decode()))
+
+    assert "latitude" in df.columns
+    assert "longitude" in df.columns
+    assert "lat" not in df.columns, "bare dimension-index column should be dropped"
+    assert "lon" not in df.columns, "bare dimension-index column should be dropped"
+    assert "spatial_ref" not in df.columns, "CRS metadata variable should be dropped"
+
+
 def test_cf_position_csv(cf_client):
     x = 204
     y = 44

--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -340,7 +340,7 @@ def test_cf_position_covjson_integer_coord(tmp_path):
 
     x, y = -121.5, 46.5
     response = client.get(
-        f"/datasets/fire/edr/position?coords=POINT({x} {y})&f=cf_covjson"
+        f"/datasets/fire/edr/position?coords=POINT({x} {y})&f=cf_covjson",
     )
 
     assert response.status_code == 200, response.text

--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -321,7 +321,7 @@ def test_cf_position_covjson_integer_coord(tmp_path):
     data = np.random.default_rng(0).random((3, 2, 2))
 
     ds = xr.Dataset(
-        {"annualFireProbability": (["year", "lat", "lon"], data)},
+        {"temperature": (["year", "lat", "lon"], data)},
         coords={
             "year": ("year", year),
             "lat": ("lat", lat),
@@ -335,18 +335,18 @@ def test_cf_position_covjson_integer_coord(tmp_path):
     ds["lon"].attrs["standard_name"] = "longitude"
     ds["lon"].attrs["axis"] = "X"
 
-    rest = xpublish.Rest({"fire": ds}, plugins={"edr": CfEdrPlugin()})
+    rest = xpublish.Rest({"climate": ds}, plugins={"edr": CfEdrPlugin()})
     client = TestClient(rest.app)
 
     x, y = -121.5, 46.5
     response = client.get(
-        f"/datasets/fire/edr/position?coords=POINT({x} {y})&f=cf_covjson",
+        f"/datasets/climate/edr/position?coords=POINT({x} {y})&f=cf_covjson",
     )
 
     assert response.status_code == 200, response.text
     data_json = response.json()
     assert "ranges" in data_json
-    assert "annualFireProbability" in data_json["ranges"]
+    assert "temperature" in data_json["ranges"]
 
 
 def test_to_csv_drops_index_only_dims_and_crs_vars():
@@ -368,7 +368,7 @@ def test_to_csv_drops_index_only_dims_and_crs_vars():
     data = np.ones((2, 1, 1))
 
     ds = xr.Dataset(
-        {"annualFireProbability": (["year", "lat", "lon"], data)},
+        {"temperature": (["year", "lat", "lon"], data)},
         coords={
             "year": ("year", year),
             "longitude": (["lat", "lon"], np.array([[-95.8]])),

--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -309,6 +309,46 @@ def test_cf_position_query(cf_client, cf_air_dataset, cf_temp_dataset):
     assert len(temp_range["values"]) == 1, "There should be 1 value selected"
 
 
+def test_cf_position_covjson_integer_coord(tmp_path):
+    """CovJSON formatter should not crash when coordinates have integer dtype."""
+    import numpy as np
+    import xarray as xr
+    import xpublish
+
+    year = np.array([1995, 2020, 2025], dtype="int32")
+    lat = np.array([46.0, 47.0], dtype="float64")
+    lon = np.array([-122.0, -121.0], dtype="float64")
+    data = np.random.default_rng(0).random((3, 2, 2))
+
+    ds = xr.Dataset(
+        {"annualFireProbability": (["year", "lat", "lon"], data)},
+        coords={
+            "year": ("year", year),
+            "lat": ("lat", lat),
+            "lon": ("lon", lon),
+        },
+    )
+    ds["lat"].attrs["units"] = "degrees_north"
+    ds["lat"].attrs["standard_name"] = "latitude"
+    ds["lat"].attrs["axis"] = "Y"
+    ds["lon"].attrs["units"] = "degrees_east"
+    ds["lon"].attrs["standard_name"] = "longitude"
+    ds["lon"].attrs["axis"] = "X"
+
+    rest = xpublish.Rest({"fire": ds}, plugins={"edr": CfEdrPlugin()})
+    client = TestClient(rest.app)
+
+    x, y = -121.5, 46.5
+    response = client.get(
+        f"/datasets/fire/edr/position?coords=POINT({x} {y})&f=cf_covjson"
+    )
+
+    assert response.status_code == 200, response.text
+    data_json = response.json()
+    assert "ranges" in data_json
+    assert "annualFireProbability" in data_json["ranges"]
+
+
 def test_cf_position_csv(cf_client):
     x = 204
     y = 44

--- a/xpublish_edr/formats/to_covjson.py
+++ b/xpublish_edr/formats/to_covjson.py
@@ -97,7 +97,10 @@ def to_cf_covjson(ds: xr.Dataset) -> CovJSON:
             values = da.dt.strftime("%Y-%m-%dT%H:%M:%S%Z").values.tolist()
         else:
             values = da.values
-            values = np.where(np.isnan(values), None, values).tolist()
+            if da.dtype.kind in ("f", "c"):
+                values = np.where(np.isnan(values), None, values).tolist()
+            else:
+                values = values.tolist()
         try:
             if not isinstance(values, list):
                 try:
@@ -145,14 +148,14 @@ def to_cf_covjson(ds: xr.Dataset) -> CovJSON:
             values = da.dt.strftime("%Y-%m-%dT%H:%M:%S%Z").values.tolist()
             dataType = "string"
         else:
-            values = np.where(np.isnan(values), None, values).tolist()
-
             if da.dtype.kind in ("i", "u"):
-                values = [int(v) for v in values]
+                values = values.tolist()
                 dataType = "integer"
             elif da.dtype.kind in ("f", "c"):
+                values = np.where(np.isnan(values), None, values).tolist()
                 dataType = "float"
             else:
+                values = values.tolist()
                 dataType = "string"
 
         cov_range = {

--- a/xpublish_edr/formats/to_csv.py
+++ b/xpublish_edr/formats/to_csv.py
@@ -8,9 +8,20 @@ from fastapi import Response
 
 def to_csv(ds: xr.Dataset):
     """Return a CSV response from an xarray dataset"""
-    df = ds.to_dataframe()
+    # Drop CRS grid-mapping variables (scalar integer blobs written by rioxarray)
+    crs_vars = [name for name, var in ds.variables.items() if "grid_mapping_name" in var.attrs]
+    if crs_vars:
+        ds = ds.drop_vars(crs_vars)
 
-    csv = df.to_csv()
+    # Dimensions with no coordinate values become meaningless 0-based integer index
+    # columns after to_dataframe() (e.g. lat/lon dims after project_dataset drops
+    # their original values and replaces them with 2D latitude/longitude coords)
+    index_only_dims = [dim for dim in ds.dims if dim not in ds.coords]
+
+    df = ds.to_dataframe().reset_index()
+    df = df.drop(columns=[c for c in index_only_dims if c in df.columns])
+
+    csv = df.to_csv(index=False)
 
     return Response(
         csv,

--- a/xpublish_edr/formats/to_csv.py
+++ b/xpublish_edr/formats/to_csv.py
@@ -9,7 +9,9 @@ from fastapi import Response
 def to_csv(ds: xr.Dataset):
     """Return a CSV response from an xarray dataset"""
     # Drop CRS grid-mapping variables (scalar integer blobs written by rioxarray)
-    crs_vars = [name for name, var in ds.variables.items() if "grid_mapping_name" in var.attrs]
+    crs_vars = [
+        name for name, var in ds.variables.items() if "grid_mapping_name" in var.attrs
+    ]
     if crs_vars:
         ds = ds.drop_vars(crs_vars)
 


### PR DESCRIPTION
## Summary

- `np.isnan` does not support integer or non-float dtypes, causing a \`TypeError\` when a dataset has integer coordinates (e.g. \`year: int32\`) or integer data variables
- Fix by checking \`dtype.kind\` before calling \`np.isnan\` — skip the NaN replacement for \`i\`/\`u\`/other non-float kinds, which cannot contain NaN anyway
- Fix \`to_csv\` to drop scalar CRS grid-mapping variables (written by \`rioxarray.write_crs()\`) and bare dimension-index columns (dimensions with no coordinate values) that appear after \`project_dataset\` reprojects a dataset
- Adds regression tests for both fixes

## Context

The CovJSON formatter called \`np.isnan\` unconditionally on coordinate and data variable values before checking dtype, so any dataset with integer coordinates or integer data variables would raise a \`TypeError\`. Similarly, after CRS reprojection the CSV formatter would emit meaningless \`lat=0, lon=0\` index columns and scalar \`crs\`/\`spatial_ref\` noise columns.

## Risk level

Low — the CovJSON change only skips \`np.isnan\` for types that can never hold NaN; existing float behaviour is unchanged. The CSV change adds \`reset_index()\` and drops provably-uninformative columns.

## Reviews

No required reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Matthew Iannucci