### PR TITLE
fix: Fix unicode coordinate selection

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # xpublish_edr documentation build configuration file, created by
 # sphinx-quickstart on Mon Oct  9 21:28:42 2017.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,7 +58,7 @@ author = "Alex Kerney"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-from xpublish_edr import __version__ as VERSION  # noqa
+from xpublish_edr import __version__ as VERSION
 
 version = VERSION
 # The full version, including alpha/beta/rc tags.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,15 @@ lint.extend-select = [
   "T20", # flake8-print
   "UP",  # pyupgrade
 ]
+lint.ignore = [
+  "BLE001", # blanket `except Exception` with a logged fallback is intentional here
+  "S110",   # permissive `try`/`except`/`pass` fallbacks are intentional here
+  "TRY004", # ValueError (not TypeError) is what gets mapped to HTTP 400 responses
+]
+lint.per-file-ignores."xpublish_edr/plugin.py" = [
+  "B008",   # FastAPI `Depends(...)` in argument defaults is idiomatic
+  "RUF012", # pydantic model fields; defaults are copied per-instance
+]
 
 [tool.repo-review]
 ignore = [

--- a/tests/test_cf_router.py
+++ b/tests/test_cf_router.py
@@ -404,7 +404,7 @@ def test_cf_position_csv(cf_client):
 
     # single time step test
     response = cf_client.get(
-        f"/datasets/air/edr/position?coords=POINT({x} {y})&f=csv&parameter-name=air&datetime=2013-01-01T00:00:00",  # noqa
+        f"/datasets/air/edr/position?coords=POINT({x} {y})&f=csv&parameter-name=air&datetime=2013-01-01T00:00:00",
     )
 
     assert response.status_code == 200, "Response did not return successfully"
@@ -496,7 +496,7 @@ def test_cf_position_parquet(cf_client) -> None:
 
     # single time step test
     response = cf_client.get(
-        f"/datasets/air/edr/position?coords=POINT({x} {y})&f=parquet&parameter-name=air&datetime=2013-01-01T00:00:00",  # noqa
+        f"/datasets/air/edr/position?coords=POINT({x} {y})&f=parquet&parameter-name=air&datetime=2013-01-01T00:00:00",
     )
 
     assert response.status_code == 200, "Response did not return successfully"
@@ -1095,7 +1095,7 @@ def test_cf_generic_extents_band_and_step():
     lon_pt = 21.5
     lat_pt = 11.0
     response = client.get(
-        f"/datasets/custom/edr/position?coords=POINT({lon_pt} {lat_pt})&parameter-name=var&step=6h&band=2&f=csv",  # noqa
+        f"/datasets/custom/edr/position?coords=POINT({lon_pt} {lat_pt})&parameter-name=var&step=6h&band=2&f=csv",
     )
     assert response.status_code == 200, "Position query should return successfully"
     assert "text/csv" in response.headers["content-type"], "Should return CSV"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -484,6 +484,31 @@ def test_select_string_dim(regular_xy_dataset_with_string_dim):
     assert ds["air"].shape == (1, 25, 53), "Dataset shape is incorrect"
 
 
+@pytest.mark.skipif(
+    not hasattr(np.dtypes, "StringDType"),
+    reason="variable-width StringDType requires numpy >= 2.0",
+)
+def test_select_vlen_string_dim(regular_xy_dataset_with_string_dim):
+    """Variable-width string coords (numpy 2 StringDType, produced by zarr v3
+    string arrays) must be equality-selected, not nearest-selected"""
+    ds = regular_xy_dataset_with_string_dim
+    ds = ds.assign_coords(stat=ds["stat"].astype(np.dtypes.StringDType()))
+
+    query = EDRPositionQuery(
+        coords="POINT(200 45)",
+        datetime="2013-01-01T06:00:00",
+        parameters="air",
+    )
+
+    ds = query.select(
+        ds,
+        {
+            "stat": "none",
+        },
+    )
+    assert ds["air"].shape == (1, 25, 53), "Dataset shape is incorrect"
+
+
 @pytest.fixture(scope="function")
 def dataset_with_non_indexed_axes():
     """Creates a dataset with non-indexed CF axis coordinates (like GFS forecast)"""

--- a/xpublish_edr/metadata.py
+++ b/xpublish_edr/metadata.py
@@ -322,7 +322,7 @@ def temporal_extent(ds: xr.Dataset) -> TemporalExtent | None:
     return TemporalExtent(
         interval=[str(time_min), str(time_max)],
         values=[f"{time_min}/{time_max}"],
-        trs='TIMECRS["DateTime",TDATUM["Gregorian Calendar"],CS[TemporalDateTime,1],AXIS["Time (T)",unspecified]]',  # noqa
+        trs='TIMECRS["DateTime",TDATUM["Gregorian Calendar"],CS[TemporalDateTime,1],AXIS["Time (T)",unspecified]]',
     )
 
 
@@ -341,7 +341,7 @@ def vertical_extent(ds: xr.Dataset) -> VerticalExtent | None:
     return VerticalExtent(
         interval=[min_z, max_z],
         values=[float(v) for v in np.asarray(elevations).tolist()],
-        vrs=f"VERTCRS[VERT_CS['unknown'],AXIS['Z',{positive}],UNIT[{units},1]]",  # noqa
+        vrs=f"VERTCRS[VERT_CS['unknown'],AXIS['Z',{positive}],UNIT[{units},1]]",
     )
 
 
@@ -508,11 +508,11 @@ def position_query_description(
             templated=True,
             variables=VariablesMetadata(
                 title="Position query",
-                description="Returns position data based on WKT `POINT(lon lat)` or `MULTIPOINT(lon lat, ...)` coordinates",  # noqa
+                description="Returns position data based on WKT `POINT(lon lat)` or `MULTIPOINT(lon lat, ...)` coordinates",
                 query_type="position",
                 coords={
                     "type": "string",
-                    "description": "WKT `POINT(lon lat)` or `MULTIPOINT(lon lat, ...)` coordinates",  # noqa
+                    "description": "WKT `POINT(lon lat)` or `MULTIPOINT(lon lat, ...)` coordinates",
                     "required": True,
                 },
                 output_formats=output_formats,
@@ -538,7 +538,7 @@ def area_query_description(
             templated=True,
             variables=VariablesMetadata(
                 title="Area query",
-                description="Returns data in a polygon based on WKT `POLYGON(lon lat, ...)` coordinates",  # noqa
+                description="Returns data in a polygon based on WKT `POLYGON(lon lat, ...)` coordinates",
                 query_type="area",
                 coords={
                     "type": "string",

--- a/xpublish_edr/query.py
+++ b/xpublish_edr/query.py
@@ -175,7 +175,7 @@ class EDRPositionQuery(BaseEDRQuery):
     @field_validator("format", mode="before")
     def validate_format(cls, v):
         """Validate the format is a valid position format"""
-        if v not in position_formats().keys():
+        if v not in position_formats():
             raise ValueError(f"Invalid format: {v}")
         return v
 
@@ -208,7 +208,7 @@ class EDRAreaQuery(BaseEDRQuery):
     @field_validator("format", mode="before")
     def validate_format(cls, v):
         """Validate the format is a valid area format"""
-        if v not in area_formats().keys():
+        if v not in area_formats():
             raise ValueError(f"Invalid format: {v}")
         return v
 
@@ -238,7 +238,7 @@ class EDRCubeQuery(BaseEDRQuery):
     @field_validator("format", mode="before")
     def validate_format(cls, v):
         """Validate the format is a valid cube format"""
-        if v not in cube_formats().keys():
+        if v not in cube_formats():
             raise ValueError(f"Invalid format: {v}")
         return v
 

--- a/xpublish_edr/query.py
+++ b/xpublish_edr/query.py
@@ -4,7 +4,6 @@ OGC EDR Query param parsing
 
 from typing import Literal
 
-import numpy as np
 import pandas as pd
 import xarray as xr
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -117,8 +116,10 @@ class BaseEDRQuery(BaseModel):
         sliced_sel_params = {}
         for key, value in query_params.items():
             # String dimensions are not sliced but they cannot be interpolated so
-            # we select them directly using equality
-            if ds[key].dtype.type is np.str_:
+            # we select them directly using equality. Kind "U" is fixed-width
+            # unicode, "T" is numpy 2's variable-width string dtype (what zarr
+            # v3 string arrays decode to).
+            if ds[key].dtype.kind in "UT":
                 sliced_sel_params[key] = value
                 continue
 


### PR DESCRIPTION
Selecting dimensions with a StringDType coord threw 

```
TypeError: unsupported operand type(s) for -: 'str' and 'str'
```
